### PR TITLE
Show hide fix

### DIFF
--- a/BetMas/modules/item.xqm
+++ b/BetMas/modules/item.xqm
@@ -114,7 +114,7 @@ Not sure how to do this? Have a look at the <a href="/Guidelines">Beta maṣā�
 <span class="w3-text w3-tag itemoptiontooltip">Click here to hide or show again the little arrows and small left pointing hands in this page.</span>
 </div>
 <div class="w3-bar-item w3-tooltip" >
-<a class="w3-button w3-padding-small w3-gray" id="toogleSeeAlso">Hide/show related</a>
+<a class="w3-button w3-padding-small w3-gray" id="toggleSeeAlso">Hide/show related</a>
 <span class="w3-text w3-tag itemoptiontooltip">Click here to hide or show again the right side of the content area, where related items and keywords are shown.</span>
 </div>
             

--- a/BetMas/modules/item.xqm
+++ b/BetMas/modules/item.xqm
@@ -110,11 +110,11 @@ Not sure how to do this? Have a look at the <a href="/Guidelines">Beta maṣā�
 </span>
     </div>
 <div class="w3-bar-item w3-tooltip" >
-<a class="w3-button w3-padding-small w3-gray" id="toggleHands">Hide/show pointers</a>
+<a class="w3-button w3-padding-small w3-gray" id="toggleHands"><span class="showHideText">Hide</span> pointers</a>
 <span class="w3-text w3-tag itemoptiontooltip">Click here to hide or show again the little arrows and small left pointing hands in this page.</span>
 </div>
 <div class="w3-bar-item w3-tooltip" >
-<a class="w3-button w3-padding-small w3-gray" id="toggleSeeAlso">Hide/show related</a>
+<a class="w3-button w3-padding-small w3-gray" id="toggleSeeAlso"><span class="showHideText">Hide</span> related</a>
 <span class="w3-text w3-tag itemoptiontooltip">Click here to hide or show again the right side of the content area, where related items and keywords are shown.</span>
 </div>
             


### PR DESCRIPTION
Minor fix that remakes some changes from 45ccd1c16dc8d4f5dd95696d847ab69b945c6714 that were undone in b41edcba1c92cfde776648b368f4ac9e112c9f38. The existence of `span.showHideText` isn't so important, but the changing of 'toggle' back to 'toogle' brought about a disagreement with the scripts in `w3.js`.