### PR TITLE
ci and regex fixes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,6 +7,10 @@ on:
       - completed
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: betamasaheft/betamasaheft
@@ -15,8 +19,13 @@ jobs:
   build:
     name: Build and Push Multi-Arch Image
     runs-on: ubuntu-latest
-    # Only run if format check workflow succeeded (or if manually triggered)
-    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
+    # Only build and push images from master: after a successful format check
+    # on master, or when manually dispatched on master
+    if: >-
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'master') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
     permissions:
       contents: read
       packages: write
@@ -78,4 +87,3 @@ jobs:
           cache-to: type=gha,mode=max
           secrets: |
             "github_token=${{ secrets.BOT_CONTAINER_PAT }}"
-

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -83,7 +83,8 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.image_tag }}
           build-args: |
             EXISTDB_VERSION=${{ matrix.existdb_version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.existdb_version }}
+          # ignore-error: a failed cache export must not fail an otherwise successful build
+          cache-to: type=gha,mode=max,scope=${{ matrix.existdb_version }},ignore-error=true
           secrets: |
             "github_token=${{ secrets.BOT_CONTAINER_PAT }}"

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,10 @@
 # local dev stuff
 node_modules/
 .env
+
+.vscode/
+.zed/
+.cursor/
+
+.moderne/
+.claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG EXISTDB_VERSION=6.4.0
+ARG EXISTDB_VERSION=6.4.1
 FROM ubuntu:latest AS build
 
 # zip and git are needed to make xars and clone repos

--- a/db/apps/BetMasWeb/modules/apprest.xqm
+++ b/db/apps/BetMasWeb/modules/apprest.xqm
@@ -3463,7 +3463,7 @@ declare function apprest:compareMssFromForm ($target-work as xs:string?) {
       let $Additems :=
       $apprest:collection-rootMS//t:additions//t:item[descendant::t:title[@ref]]
       let $matchingAddmss := $Additems//t:title[contains(@ref, $target-work)]
-      let $matchingConmss := $items/t:title[matches(@ref, $target-work)]
+      let $matchingConmss := $items/t:title[contains(@ref, $target-work)]
       let $matchingmss := ($matchingConmss, $matchingAddmss)
       let $ids :=
         for $manuscript in $matchingmss

--- a/db/apps/BetMasWeb/modules/charts.xqm
+++ b/db/apps/BetMasWeb/modules/charts.xqm
@@ -51,8 +51,8 @@ declare function charts:mssSankey($itemid){
 
   let $sparqlresults := fusekisparql:query('betamasaheft',$query)
   let $results := for $result in $sparqlresults//sr:result
-                 let $from := substring-after($result//sr:binding[1]/sr:uri, 'https://betamasaheft.eu/')
-                 let $to := substring-after($result//sr:binding[2]/sr:uri, 'https://betamasaheft.eu/')
+                 let $from := substring-after($result//sr:binding[1]/sr:uri, $config:BMurl)
+                 let $to := substring-after($result//sr:binding[2]/sr:uri, $config:BMurl)
                  let $w := $result//sr:binding[3]/sr:literal
                  return '["' ||  $from || '", "' || $to || '", ' ||  $w || ']'
 

--- a/db/apps/BetMasWeb/modules/config.xqm
+++ b/db/apps/BetMasWeb/modules/config.xqm
@@ -47,6 +47,18 @@ declare variable $config:appUrl := $loc:appUrl;
 
 declare variable $config:baseURI := $config:appUrl || "/";
 
+(:~
+ : Canonical Beta maṣāḥǝft URI prefix as baked into the expanded data by
+ : expand.xqm (must match $expand:BMurl there). Use this to recognise and
+ : strip the prefix from identifiers stored in the data (@ref, @corresp,
+ : facet values, ...).
+ :
+ : This is deliberately NOT $config:appUrl: appUrl describes where this
+ : instance is currently served (and is empty in the container), whereas
+ : the data always carries this canonical prefix regardless of host.
+ :)
+declare variable $config:BMurl := 'https://betamasaheft.eu/';
+
 declare variable $config:DOI := '10.25592/BetaMasaheft';
 
 declare variable $config:response200 := <rest:response>

--- a/db/apps/BetMasWeb/modules/coordinates.xqm
+++ b/db/apps/BetMasWeb/modules/coordinates.xqm
@@ -46,8 +46,8 @@ let $seq := for $point in tokenize($coord, ' ') return $point
  : first looks at what the id is, then if it is one of ours, looks for coordinates
  : 1. take ours if we have them, if not look for a sameAs and check there for coordinates:)
 declare function coord:getCoords($placenameref as xs:string) {
-    if (starts-with($placenameref, 'https://betamasaheft.eu/LOC') or starts-with($placenameref, 'https://betamasaheft.eu/INS')) then
-        let $onlyid := substring-after($placenameref, 'https://betamasaheft.eu/')
+    if (starts-with($placenameref, $config:BMurl || 'LOC') or starts-with($placenameref, $config:BMurl || 'INS')) then
+        let $onlyid := substring-after($placenameref, $config:BMurl)
         let $pRec := collection($config:data-rootPl,$config:data-rootIn)/id($onlyid)
          return
          if ($pRec//t:geo[@rend eq 'polygon']/text()) then

--- a/db/apps/BetMasWeb/modules/dts.xqm
+++ b/db/apps/BetMasWeb/modules/dts.xqm
@@ -1624,7 +1624,7 @@ switch($name)
                             case 'keywords' return $file//t:term[@key][not(parent::t:keywords)]
                             default return ()
 else
-let $cleanid := replace($id, 'https://betamasaheft.eu/', '')
+let $cleanid := replace($id, $config:BMurl, '')
 return
 switch($name)
                             case 'places' return $file//t:placeName[@ref =$cleanid]
@@ -1763,7 +1763,7 @@ function dts:WebAnnotationsIndex($coll as xs:string*, $id as xs:string*,
 $indexName as xs:string*,
 $begin as xs:string*, $page as xs:string*, $version as xs:string*){
 let $parsedURN := dts:parseDTS($id)
-let $BMid := if(matches($id,'https://betamasaheft.eu')) then $parsedURN//s:group[@nr=3]//text() else $id
+let $BMid := if(contains($id, $config:BMurl)) then $parsedURN//s:group[@nr=3]//text() else $id
 (:if $indexName is items then list each item in the collection as annotation collection
 else print all paginated values for that index in the collection:)
 let $indexEntries := if($indexName='items')

--- a/db/apps/BetMasWeb/modules/dtslib.xqm
+++ b/db/apps/BetMasWeb/modules/dtslib.xqm
@@ -1809,7 +1809,7 @@ switch($name)
                             case 'keywords' return $file//t:term[@key][not(parent::t:keywords)]
                             default return ()
 else 
-let $cleanid := replace($id, 'https://betamasaheft.eu/', '')
+let $cleanid := replace($id, $config:BMurl, '')
 return
 switch($name) 
                             case 'places' return $file//t:placeName[@ref =$cleanid]

--- a/db/apps/BetMasWeb/modules/exptit.xqm
+++ b/db/apps/BetMasWeb/modules/exptit.xqm
@@ -36,9 +36,9 @@ if(count($titleMe) = 0 or $titleMe = "" ) then () else
         default
             return
                 (:            the string could be really just anything, but in the expanded data, it will often be a URI, maybe prefixed with the official betmas URI.:)
-                if (starts-with($titleMe, 'https://betamasaheft.eu')) then
+                if (starts-with($titleMe, $config:BMurl)) then
                     (:                check if it is a local URI :)
-                    let $id := substring-after($titleMe, concat('https://betamasaheft.eu', '/'))
+                    let $id := substring-after($titleMe, $config:BMurl)
                     return
                         exptit:printTitleID($id)
                 else
@@ -102,7 +102,7 @@ function exptit:printTitleID($id as xs:string)
     (: if the id has a subid, than split it :)
     else if (contains($id, '#')) then
     (   let $mainIDstart := substring-before($id, '#')
-        let $mainID := if(starts-with($mainIDstart, $config:baseURI)) then substring-after($mainIDstart, $config:baseURI) else $mainIDstart
+        let $mainID := if(starts-with($mainIDstart, $config:BMurl)) then substring-after($mainIDstart, $config:BMurl) else $mainIDstart
         let $SUBid := substring-after($id, '#')
         let $node := $exptit:col//id($mainID)
         return

--- a/db/apps/BetMasWeb/modules/item.xqm
+++ b/db/apps/BetMasWeb/modules/item.xqm
@@ -415,14 +415,14 @@ case 'manuscripts' return
              let $repoplace := if ($repodoc//t:settlement[1]/@ref) then exptit:printTitleID($repodoc//t:settlement[1]/@ref) else if ($repodoc//t:settlement[1]/text()) then $repodoc//t:settlement[1]/text() else if ($repodoc//t:country[1]/@ref) then exptit:printTitleID($repodoc//t:country[1]/@ref) else ()
 return
             (<a target="_blank"
-            href="{$config:appUrl}/newSearch.html?searchType=text&amp;mode=any&amp;reporef={replace($repo, concat($config:appUrl, '/'), '')}"
+            href="{$config:appUrl}/newSearch.html?searchType=text&amp;mode=any&amp;reporef={tokenize($repo, '/')[last()]}"
             role="button"
             class="w3-tag w3-gray w3-large w3-margin-top"
             property="http://www.cidoc-crm.org/cidoc-crm/P55_has_current_location"
             resource="{$repo}">{if($repoplace) then ($repoplace, ', ') else ()}
                    {string($this//t:msIdentifier/t:repository/text())}</a>,
                   <a target="_blank"
-            href="{replace($repo, $config:appUrl, '')}">
+            href="/{tokenize($repo, '/')[last()]}">
                    <sup>[view repository]</sup></a>)
                   }
 

--- a/db/apps/BetMasWeb/modules/item.xqm
+++ b/db/apps/BetMasWeb/modules/item.xqm
@@ -415,14 +415,14 @@ case 'manuscripts' return
              let $repoplace := if ($repodoc//t:settlement[1]/@ref) then exptit:printTitleID($repodoc//t:settlement[1]/@ref) else if ($repodoc//t:settlement[1]/text()) then $repodoc//t:settlement[1]/text() else if ($repodoc//t:country[1]/@ref) then exptit:printTitleID($repodoc//t:country[1]/@ref) else ()
 return
             (<a target="_blank"
-            href="{$config:appUrl}/newSearch.html?searchType=text&amp;mode=any&amp;reporef={tokenize($repo, '/')[last()]}"
+            href="{$config:appUrl}/newSearch.html?searchType=text&amp;mode=any&amp;reporef={if (starts-with($repo, $config:BMurl)) then substring-after($repo, $config:BMurl) else $repo}"
             role="button"
             class="w3-tag w3-gray w3-large w3-margin-top"
             property="http://www.cidoc-crm.org/cidoc-crm/P55_has_current_location"
             resource="{$repo}">{if($repoplace) then ($repoplace, ', ') else ()}
                    {string($this//t:msIdentifier/t:repository/text())}</a>,
                   <a target="_blank"
-            href="/{tokenize($repo, '/')[last()]}">
+            href="/{if (starts-with($repo, $config:BMurl)) then substring-after($repo, $config:BMurl) else $repo}">
                    <sup>[view repository]</sup></a>)
                   }
 

--- a/db/apps/BetMasWeb/modules/queries.xqm
+++ b/db/apps/BetMasWeb/modules/queries.xqm
@@ -1706,15 +1706,15 @@ declare function q:facetDiv($f, $facets, $facetTitle) {
                                                 $q:languages//t:item[@xml:id eq $label]/text()
                                             else
                                                 if ($f = 'keywords') then
-                                                    let $cleanlabel := if (starts-with($label, $config:appUrl)) then
-                                                        replace(substring-after($label, $config:appUrl), '/', '')
+                                                    let $cleanlabel := if (starts-with($label, $config:BMurl)) then
+                                                        substring-after($label, $config:BMurl)
                                                     else
                                                         $label
                                                     let $taxname := (id($cleanlabel, $q:tax)/self::t:category | $q:tax//t:category[t:catDesc eq $cleanlabel])[1]/t:catDesc/text()
                                                     return
                                                         $taxname
                                                 else
-                                                    if (starts-with($label, $config:appUrl)) then
+                                                    if (starts-with($label, $config:BMurl)) then
                                                         exptit:printTitle($label)
                                                     else
                                                         $label
@@ -1726,8 +1726,8 @@ declare function q:facetDiv($f, $facets, $facetTitle) {
                                 if ($f = 'keywords') then
                                     (for $input in $inputs
                                     let $val := $input/*:input/@value
-                                    let $cleanval := if (starts-with($val, $config:appUrl)) then
-                                        replace(substring-after($val, $config:appUrl), '/', '')
+                                    let $cleanval := if (starts-with($val, $config:BMurl)) then
+                                        substring-after($val, $config:BMurl)
                                     else
                                         $val
                                     let $kk := ($q:tax//t:category[t:catDesc eq $val] | $q:tax//t:category[@xml:id eq $val])

--- a/db/apps/BetMasWeb/modules/queries.xqm
+++ b/db/apps/BetMasWeb/modules/queries.xqm
@@ -3335,7 +3335,7 @@ declare function q:summaryWork($item, $id) {
                             else
                                 $rpass
                         for $author in distinct-values($attributions)
-                        let $id := replace($author, 'https://betamasaheft.eu/', '')
+                        let $id := replace($author, $config:BMurl, '')
                         return
                             <li><a
                                     href="{$config:appUrl}/{$author}">{
@@ -3361,7 +3361,7 @@ declare function q:summaryWork($item, $id) {
                     {
                         for $witness in $item//t:listWit/t:witness
                         let $corr := $witness/@corresp
-                        let $id := replace($corr, 'https://betamasaheft.eu/', '')
+                        let $id := replace($corr, $config:BMurl, '')
                         return
                             <li><a
                                     href="{$config:appUrl}/{$corr}">{exptit:printTitleID($id)}</a></li>
@@ -3372,7 +3372,7 @@ declare function q:summaryWork($item, $id) {
                     {
                         for $parallel in ($isVersion, $anotherlang)
                         let $p := $parallel/@active
-                        let $id := replace($parallel, 'https://betamasaheft.eu/', '')
+                        let $id := replace($parallel, $config:BMurl, '')
                         return
                             <li><a
                                     href="{$config:appUrl}/{$p}">{$id}</a></li>
@@ -3792,10 +3792,10 @@ let $t2 := util:log('info', $count):)
     (:let $t3 := util:log('info', $formatoptions):)
     let $options := for $option in $formatoptions
     return
-        if (starts-with($key, 'https://betamasaheft.eu/') and contains($key, '#'))
+        if (starts-with($key, $config:BMurl) and contains($key, '#'))
         then
             try {
-                let $id := replace($key, 'https://betamasaheft.eu/', '')
+                let $id := replace($key, $config:BMurl, '')
                 let $subid := substring-after($key, '#')
                 let $mainid := substring-before($key, '#')
                     group by $MAIN := $mainid
@@ -3834,9 +3834,9 @@ declare function q:formatOption($rangeindexname, $key, $count) {
                     value="{$key}">{editors:editorKey(substring-after($key, '#'))} ({$count[2]})</option>
 
             else
-                if (starts-with($key, 'https://betamasaheft.eu/'))
+                if (starts-with($key, $config:BMurl))
                 then
-                    let $id := replace($key, 'https://betamasaheft.eu/', '')
+                    let $id := replace($key, $config:BMurl, '')
                     let $title := ($q:lists//t:item[@xml:id = $id] | $q:lists//t:item[@corresp = $id])/text()
                     let $titlesel := if ($title) then
                         $title

--- a/db/apps/BetMasWeb/modules/timeline.xqm
+++ b/db/apps/BetMasWeb/modules/timeline.xqm
@@ -34,7 +34,7 @@ tl:date($date, 'obj')
 let $datePersons :=
 let $datesOfThisPerson := $this//t:person[t:birth[@evidence eq  "internal"][@when or @notBefore or @notAfter] or t:death[@evidence eq  "internal"][@when or @notBefore or @notAfter] or t:floruit[@evidence eq  "internal"][@when or @notBefore or @notAfter]]
 let $datesofRelatedPersons := for $ref in config:distinct-values($this//@ref[contains(.,'PRS')])
-return doc(($config:data-rootPr || '/' ||substring-after($ref, 'https://betamasaheft.eu/')|| '.xml'))//t:person[t:birth[@evidence eq  "internal"][@when or @notBefore or @notAfter] or t:death[@evidence eq  "internal"][@when or @notBefore or @notAfter] or t:floruit[@evidence eq  "internal"][@when or @notBefore or @notAfter]]
+return doc(($config:data-rootPr || '/' ||substring-after($ref, $config:BMurl)|| '.xml'))//t:person[t:birth[@evidence eq  "internal"][@when or @notBefore or @notAfter] or t:death[@evidence eq  "internal"][@when or @notBefore or @notAfter] or t:floruit[@evidence eq  "internal"][@when or @notBefore or @notAfter]]
 let $datesIncitingPrs := for $citingpr in config:distinct-values($whatpointshere[ancestor::t:TEI[@type eq 'pers']]/ancestor::t:TEI/@xml:id) return doc(($config:data-rootPr || '/' ||string($citingpr)|| '.xml'))//t:person[t:birth[@evidence eq  "internal"][@when or @notBefore or @notAfter] or t:death[@evidence eq  "internal"][@when or @notBefore or @notAfter] or t:floruit[@evidence eq  "internal"][@when or @notBefore or @notAfter]]
 
 for $datep in ($datesOfThisPerson, $datesofRelatedPersons)

--- a/db/apps/BetMasWeb/modules/viewItem.xqm
+++ b/db/apps/BetMasWeb/modules/viewItem.xqm
@@ -852,10 +852,10 @@ declare %private function viewItem:URI2ID($string) {
 };
 
 declare %private function viewItem:ID2URI($string) {
-    if (starts-with($string, 'https://betamasaheft.eu')) then
+    if (starts-with($string, $config:BMurl)) then
         $string
     else
-        'https://betamasaheft.eu' || '/' || $string
+        $config:BMurl || $string
 };
 
 declare %private function viewItem:workAuthLi($a, $aorp) {

--- a/db/apps/BetMasWeb/restviews/collatex.xqm
+++ b/db/apps/BetMasWeb/restviews/collatex.xqm
@@ -175,7 +175,7 @@ return
 
 (:~ Produces as string a json object which contains the id of the manuscript witnesses selected and the text passege as of the urn  which can be used to build the body of a post request to collatex:)
 declare function collatex:getCollatexWitnessText($dtsURN){
-let $parsedURN := dtslib:parseDTSid(replace($dtsURN, 'https://betamasaheft.eu/', ''))
+let $parsedURN := dtslib:parseDTSid(replace($dtsURN, $config:BMurl, ''))
 (:let $test := console:log($parsedURN):)
 let $id := $parsedURN//s:group[@nr = 1]/text()
 let $edition := $parsedURN//s:group[@nr = 2]

--- a/db/apps/BetMasWeb/restviews/genderInfo.xqm
+++ b/db/apps/BetMasWeb/restviews/genderInfo.xqm
@@ -110,7 +110,7 @@ declare function genderInfo:timeline($sparql){
 for $res in $sparql//sr:result[sr:binding[@name eq 'birth']]
 let $person := $res//sr:binding[@name eq 'person']/sr:uri/text() 
             group by $p := $person
-            let $id := substring-after($p,'https://betamasaheft.eu/')
+            let $id := substring-after($p, $config:BMurl)
             let $name := exptit:printTitleID($id)
             let $birth := $res[1]/sr:binding[@name eq 'birth']/sr:literal/text()
             let $death := $res[1]/sr:binding[@name eq 'birth']/sr:literal/text()
@@ -147,7 +147,7 @@ declare function genderInfo:GenBarChartData($sparql){
             let $countF := genderInfo:filter($res, 'female')
              let $countM := genderInfo:filter($res, 'male')
             return 
-            "['"||substring-after(replace($r, '\s', ''), 'https://betamasaheft.eu/')||"',"|| count($countF)||','|| count($countM)||']'
+            "['"||substring-after(replace($r, '\s', ''), $config:BMurl)||"',"|| count($countF)||','|| count($countM)||']'
     
 };
  
@@ -157,8 +157,8 @@ declare
 %output:method("json")
 function genderInfo:relNodes(){
 let $nodes :=
-for $n in $genderInfo:sparqlquery[2]//sr:uri[starts-with(.,'https://betamasaheft.eu/')]
-let $id := substring-after($n,'https://betamasaheft.eu/')
+for $n in $genderInfo:sparqlquery[2]//sr:uri[starts-with(., $config:BMurl)]
+let $id := substring-after($n, $config:BMurl)
 group by $i := $id
 let $title := exptit:printTitleID($i)
 let $type := switch2:switchPrefix($i)


### PR DESCRIPTION
make sure concurrent runs don't interfere with each other, only push images from `master`

Two bug fixes revealed by the testsuite.

- invalid regex, throws in exist v6 goes unnoticed in v5
- two uses of the baseURL, one is released to actually serving the app, one to data operations. The former changes when the server changes, the latter does not. 

