### PR TITLE
[WIP] refactor(expand): decouple expansion pipeline from legacy BetMas app

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,4 +13,7 @@ db/apps/BetMas/modules/titles.xqm
 db/apps/**/clavisUpdate.xql
 db/apps/BetMasWeb/modules/exptit.xqm
 db/apps/BetMasWeb/modules/titles.xqm
+db/apps/BetMasWeb/modules/expand.xqm
+db/apps/BetMasWeb/modules/titlesData.xqm
+db/apps/BetMasWeb/modules/generateFormattedBibliography.xqm
 

--- a/db/apps/BetMasService/modules/makeExpand.xql
+++ b/db/apps/BetMasService/modules/makeExpand.xql
@@ -2,7 +2,7 @@ xquery version "3.1";
 declare namespace t = "http://www.tei-c.org/ns/1.0";
 declare namespace xi = "http://www.w3.org/2001/XInclude";
 
-import module namespace expand = "https://www.betamasaheft.uni-hamburg.de/BetMas/expand" at "xmldb:exist:///db/apps/BetMas/modules/expand.xqm";
+import module namespace expand = "https://www.betamasaheft.uni-hamburg.de/BetMas/expand" at "xmldb:exist:///db/apps/BetMasWeb/modules/expand.xqm";
 
 let $context :=
 

--- a/db/apps/BetMasWeb/modules/expand.xqm
+++ b/db/apps/BetMasWeb/modules/expand.xqm
@@ -1,11 +1,13 @@
 xquery version "3.1";
 
 module namespace expand = "https://www.betamasaheft.uni-hamburg.de/BetMas/expand";
-import module namespace titles = "https://www.betamasaheft.uni-hamburg.de/BetMas/titles" at "xmldb:exist:///db/apps/BetMasWeb/modules/titles.xqm";
-import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMas/switch2"  at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
+import module namespace titles = "https://www.betamasaheft.uni-hamburg.de/BetMas/titles" at "xmldb:exist:///db/apps/BetMasWeb/modules/titlesData.xqm";
+import module namespace gfb = "https://www.betamasaheft.uni-hamburg.de/BetMas/gfb" at "xmldb:exist:///db/apps/BetMasWeb/modules/generateFormattedBibliography.xqm";
+import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2"  at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
 import module namespace console = "http://exist-db.org/xquery/console";
 declare namespace t = "http://www.tei-c.org/ns/1.0";
 declare namespace xi = "http://www.w3.org/2001/XInclude";
+declare namespace b = "betmas.biblio";
 declare variable $expand:zotero := collection('/db/apps/EthioStudies') ;
 declare variable $expand:BMurl := 'https://betamasaheft.eu/';
 declare variable $expand:editorslist := doc('/db/apps/lists/editors.xml') ;
@@ -18,7 +20,7 @@ declare variable $expand:listPrefixDef :=
     <prefixDef
         ident="bm"
         matchPattern="([a-zA-Z0-9]+)"
-        replacementPattern="https://www.zotero.org/groups/358366/ethiostudies/items/tag/bm:$1">
+       replacementPattern="https://www.zotero.org/groups/358366/ethiostudies/items/tag/bm:$1">
     </prefixDef>
     <prefixDef
         ident="betmas"
@@ -176,6 +178,13 @@ declare function expand:id($id) {
             'https://betamasaheft.eu/' || $id
 };
 
+declare function expand:ids($node as node()) as xs:string {
+  if ($node/@xml:id) then
+    ($node/@xml:id)
+  else
+    $node/name()  || $node/ancestor-or-self::*/@xml:id [1] || $node/position()
+};
+
 declare function expand:token($val) {
     (:   refactoring from post.xslt post:token :)
     if (contains($val, ' '))
@@ -246,11 +255,15 @@ declare function expand:tei2fulltei($nodes as node()*, $bibliography) {
                         taking advantage of the <ref target="https://betamasaheft.eu">exist-db database instance</ref> where
                         the data is stored and of the many external resources to which this data points to.</p>,
                         $expand:listPrefixDef,
+let $mainid := $node/ancestor::t:TEI/@xml:id
+                        let $taxid := $expand:canontax//t:category[@xml:id]
+                        return
+                        if (not($mainid = $taxid/@xml:id)) then
                         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="xmldb:exist:///db/apps/lists/canonicaltaxonomy.xml">
             <xi:fallback>
                <p>Definitions of prefixes used.</p>
             </xi:fallback>
-         </xi:include>,
+         </xi:include> else (),
 <refsDecl xmlns="http://www.tei-c.org/ns/1.0">
 {
 let $text :=  $node/ancestor::t:TEI//t:div[@type = 'edition']
@@ -264,7 +277,7 @@ let $cS :=
         match="//div[@type='edition']"
         use="@xml:id" delim=".">
         {
-       expand:groupCS($cS)
+       expand:strip-ns(expand:groupCS($cS))
    }
     </citeStructure>
 }
@@ -287,8 +300,32 @@ let $cS :=
                 return
                     <titleStmt
                         xmlns="http://www.tei-c.org/ns/1.0">
-                        <title type="full">{try{titles:printTitleMainID(string($node/ancestor-or-self::t:TEI/@xml:id))} catch * {util:log('INFO', concat('no full title added for ', string($node/ancestor-or-self::t:TEI/@xml:id)))}}</title>
+                        <title type="full">{try{expand:printTitleMainID(string($node/ancestor-or-self::t:TEI/@xml:id))} catch * {util:log('INFO', concat('no full title added for ', string($node/ancestor-or-self::t:TEI/@xml:id)))}}</title>
                         {expand:tei2fulltei($node/node(), $bibliography)}
+                         {
+                            let $gened := $node//t:editor[@role = 'generalEditor']/@key
+                            for $resp in distinct-values($gened)
+                            return
+                                <respStmt
+                                    xml:id="ged-{$resp}"
+                                    corresp="https://betamasaheft.eu/team.html#{$resp}">
+                                    <resp>general editor</resp>
+                                    <name>{$expand:editorslist//t:item[@xml:id = string($resp)]/text()}</name>
+                                </respStmt>
+                        }
+                         {
+                            let $ekeys := $node//t:editor[not(@role = 'generalEditor')]/@key
+                            for $resp in distinct-values($ekeys)
+                            let $editor:= $node//t:editor[@key = $resp][not(@role='generalEditor')][1]
+                            let $role := $editor/@role
+                            return
+                                <respStmt
+                                    xml:id="{if ($role) then concat(substring($role,1,3),'-',$resp) else concat('ed-',$resp)}"
+                                    corresp="https://betamasaheft.eu/team.html#{$resp}">
+                                    <resp>{if ($role) then string($role) else 'editor'}</resp>
+                                    <name>{$expand:editorslist//t:item[@xml:id = string($resp)]/text()}</name>
+                                </respStmt>
+                        }
                         {
                             let $ekeys := $node//t:editor/@key
                             let $cwhos := $node/ancestor-or-self::t:TEI//t:change/@who
@@ -301,6 +338,7 @@ let $cS :=
                                     <name>{$expand:editorslist//t:item[@xml:id = string($resp)]/text()}</name>
                                 </respStmt>
                         }
+
                     </titleStmt>
             case element(t:revisionDesc)
             return
@@ -309,7 +347,7 @@ let $cS :=
                     }
            case element(t:change)
             return
-            <change xmlns="http://www.tei-c.org/ns/1.0" who="#{$node/@who}" when="{$node/@when}">{let $resp := $node/@who return $expand:editorslist//t:item[@xml:id = string($resp)]/text()}: {$node/text()}</change>
+            <change xmlns="http://www.tei-c.org/ns/1.0" who="#{$node/@who}" when="{$node/@when}"><!--{let $resp := $node/@who return $expand:editorslist//t:item[@xml:id = string($resp)]/text()}: -->{$node/text()}</change>
             case element(t:profileDesc)
                 return
                     element {fn:QName("http://www.tei-c.org/ns/1.0", name($node))} {
@@ -392,26 +430,26 @@ let $cS :=
                         else
                             (),
                         if ($node/@ref and not($node/text())) then
-                            titles:printTitleMainID($node/@ref)
+                            expand:printTitleMainID($node/@ref)
                         else
                             (),
                         if ($node/@type = 'authFile' and (string-length($node/text()) = 0)) then
-                            titles:printTitleMainID($node/@corresp)
+                            expand:printTitleMainID($node/@corresp)
                         else
                             (),
                         if ( $node[not(text())] and $node/@corresp and $node/@type[not(. ='authFile')]) then
                         let $corrnode := $node/ancestor-or-self::t:TEI/id($node/@corresp)
                         return
                             if ($corrnode) then
-                                let $buildID := titles:printTitleMainID($node/ancestor-or-self::t:TEI/@xml:id) || ' element '|| $corrnode/name()|| ' with id ' || string($node/@corresp)
+                                let $buildID := expand:printTitleMainID($node/ancestor-or-self::t:TEI/@xml:id) || ' element '|| $corrnode/name()|| ' with id ' || string($node/@corresp)
                                 return
                                     $buildID
                            else if (starts-with($node/@corresp, '#')) then
-                                let $buildID := titles:printTitleMainID($node/ancestor-or-self::t:TEI/@xml:id) || ' id ' || string($node/@corresp)
+                                let $buildID := expand:printTitleMainID($node/ancestor-or-self::t:TEI/@xml:id) || ' id ' || string($node/@corresp)
                                 return
                                     $buildID
                             else
-                                titles:printTitleMainID($node/@corresp)
+                                titles:printTitleID($node/@corresp)
                         else
                             (),
                         expand:tei2fulltei($node/node(), $bibliography))
@@ -420,13 +458,15 @@ let $cS :=
             case element(t:editor)
                 return
                     let $k := $node/@key
-
+                    let $role := $node/@role
                     return
                         element {fn:QName("http://www.tei-c.org/ns/1.0", name($node))} {
                             (
                             $node/@*,
                             attribute corresp {concat('https://betamasaheft.eu/team.html#', $k)},
-                            attribute {'xml:id'} {$k},
+                            attribute {'xml:id'} {
+                    if ($role) then concat(substring($role,1,2),'-', $k) else $k
+                },
                             $expand:editorslist//t:item[@xml:id = string($k)]/text(),
                             expand:tei2fulltei($node/node(), $bibliography)
                             )
@@ -473,7 +513,7 @@ let $cS :=
                                 (),
                             expand:tei2fulltei($node/node(), $bibliography))
                         }
-            case element(t:locus)
+   (:         case element(t:locus)
                 return
                     element {fn:QName("http://www.tei-c.org/ns/1.0", name($node))} {
                         ($node/@*,
@@ -571,7 +611,7 @@ let $cS :=
                         else
                             (),
                         expand:tei2fulltei($node/node(), $bibliography))
-                    }
+                    }:)
             case element(t:idno)
                 return
                     element {fn:QName("http://www.tei-c.org/ns/1.0", name($node))} {
@@ -580,12 +620,10 @@ let $cS :=
                             let $mainFacs := $node/@facs
                             return
                                 attribute corresp {
-                                    if (starts-with($mainFacs, 'http') or contains($mainFacs, 'vatlib') or contains($mainFacs, 'gallica')) then
-                                        $mainFacs
-                                    else    if (starts-with($mainFacs, '#')) then
+                                    if (starts-with($mainFacs, 'http') or (starts-with($mainFacs, '#')) or contains($mainFacs, 'vatlib') or contains($mainFacs, 'gallica')) then
                                         $mainFacs
                                     else
-                                        concat($expand:BMurl, 'api/iiif/', $node/ancestor-or-self::t:TEI/@xml:id/data(), '/manifest')
+                                       concat($expand:BMurl, 'api/iiif/',  $node/ancestor-or-self::t:TEI/@xml:id, '/manifest',  (if ($node/parent::t:altIdentifier/@xml:id) then '?alt=' || string($node/parent::t:altIdentifier/@xml:id) else if ($node/parent::t:altIdentifier) then '?alt=alt' else ()))
                                 }
                         else
                             (),
@@ -646,7 +684,7 @@ let $cS :=
                                  else :)
                                  expand:tei2fulltei($node/node(), $bibliography)
                         )
-                    }} catch * {util:log('INFO', $err:description), util:log('INFO', $node)}
+                    }} catch * {util:log('INFO', $err:description), util:log('INFO', (concat('error in the node ',name($node))))}
                     (:                    anything which is not a node of those named above, including text() and attributes:)
             default
                 return
@@ -748,7 +786,7 @@ return
 ,
 let $col := switch2:col($node/ancestor-or-self::t:TEI/@type) return
 (<idno xmlns="http://www.tei-c.org/ns/1.0" type="collection">{$col}</idno>,
-<idno xmlns="http://www.tei-c.org/ns/1.0" type="url">https://betamasaheft.eu/{$col}/{$id}</idno>),
+<idno xmlns="http://www.tei-c.org/ns/1.0" type="url">https://betamasaheft.eu/{$col}/{$id}/main</idno>),
 <idno xmlns="http://www.tei-c.org/ns/1.0" type="URI">https://betamasaheft.eu/{$id}</idno>,
 <idno xmlns="http://www.tei-c.org/ns/1.0" type="filename">{$id}.xml</idno>,
 <idno xmlns="http://www.tei-c.org/ns/1.0" type="ID">{$id}</idno>))
@@ -763,7 +801,7 @@ element {fn:QName("http://www.tei-c.org/ns/1.0", name($node))} {
                             case 'notBefore' return 'not before'
                             case 'notAfter' return 'not after'
                             case 'cert' return 'certainty:'
-                            case 'resp' return titles:printTitleMainID($att)
+                            case 'resp' return expand:printTitleMainID($att)
                             default return $att/name()) || ' ' || $att/data())
                         return
                             string-join($atts, ' ')
@@ -793,9 +831,17 @@ element {fn:QName("http://www.tei-c.org/ns/1.0", name($node))} {
 declare function expand:attributes($node, $bibliography) {
     element {fn:QName("http://www.tei-c.org/ns/1.0", name($node))} {
         ($node/@*[not(name() = 'corresp')][not(name() = 'resp')][not(name() = 'who')][not(name() = 'ref')][not(name() = 'sameAs')][not(name() = 'calendar')],
-        if ($node/@corresp) then
+         (
+        if (not($node/@xml:id) and $node/ancestor-or-self::t:div[@type='edition']) then
+          attribute xml:id { local-name($node)  || (if ($node/ancestor-or-self::*/@xml:id [1]) then string-join($node/ancestor-or-self::*/@xml:id [1]) || $node/position() else (generate-id())) }
+        else
+          ()),
+        if ($node/@corresp and $node[not(@type = 'external')] ) then
             attribute corresp {$expand:BMurl || (if(starts-with($node/@corresp, '#')) then string($node/ancestor-or-self::t:TEI/@xml:id) || string($node/@corresp) else string($node/@corresp))}
         else
+          if ($node/@corresp and $node[@type = 'external'] ) then
+            attribute corresp { (if(starts-with($node/@corresp, '#')) then string($node/ancestor-or-self::t:TEI/@xml:id) || string($node/@corresp) else string($node/@corresp))}
+            else
             (),
         if ($node/@calendar) then
             attribute calendar {'#' || $node/@calendar/data()}
@@ -847,10 +893,26 @@ declare function expand:wholike($attribute) {
     attribute {name($attribute)} {expand:id($attribute/data())}
 };
 
+declare function expand:syncBibliography($expanded as element()) {
+    let $bm-cites := distinct-values($expanded//t:ptr/@target[starts-with(., 'bm:')])
+    let $bibliography := doc('/db/apps/lists/bibliography.xml')/b:bibliography
+    for $cite in $bm-cites
+    let $exists := $bibliography//b:entry[@id = $cite]
+    return
+        if (empty($exists)) then
+            let $entry := gfb:updateentry($cite)
+            let $updated := update insert $entry into $bibliography/b:entries
+            let $updatetotal := update value $bibliography/b:total with count(distinct-values(($bibliography//b:entry/@id, $bm-cites)))
+            return util:log('INFO', concat('Added new bibliography entry for: ', $cite))
+        else ()
+};
+
 declare function expand:file($filepath) {
     let $doc := doc($filepath)
     (:util:expand needs to go to a node, therefore the processing instructions need to be added back:)
     let $expanded := util:expand($doc/t:TEI)
+    let $syncBib:=expand:syncBibliography($expanded)
+
     let $zotero :=
       for $ptr in distinct-values($expanded//t:ptr/@target[starts-with(., 'bm:')])
                         let $z := if($expand:zotero//t:biblStruct[t:note[@type='tags']/t:note[@type='tag'] = $ptr])
@@ -878,6 +940,18 @@ declare function expand:file($filepath) {
         }
 };
 
+declare function expand:strip-ns($nodes) {
+  for $n in $nodes
+  return
+    typeswitch($n)
+      case element()
+        return element {local-name($n)} {
+          $n/@*,
+          expand:strip-ns($n/node())
+        }
+      default return $n
+};
+
 (:
 declare function expand:optionsexpand($model, $bibliography){
 if($model/t:choice[t:corr][t:sic]) then
@@ -895,17 +969,49 @@ else
 
 declare function expand:biblCorrTok($corresp, $node){
 let $c :=if(starts-with($corresp, '#')) then concat($node/ancestor-or-self::t:TEI/@xml:id, $corresp) else string($corresp)
-let $anchor := if(starts-with($corresp, '#')) then substring-after($corresp, '#') else string($corresp)
+let $anchor := if(contains($corresp, '#')) then substring-after($corresp, '#') else string($corresp)
 let $anchornode := $node/id($anchor)
 let $listWit := if ($anchornode/name() = 'listWit') then for $witness in $anchornode return titles:printTitleID($witness/@corresp) else ()
-let $prefix := if($listWit ge 1) then $listWit else if(string-length($anchornode/name()) ge 1) then ($anchornode/name(), ', ') else ()
+let $prefix := if($listWit ge 1) then $listWit else if(string-length($anchornode/name()) ge 1) then (' ', $anchornode/name(), ' ') else ()
 let $lang := if (string-length($anchornode/@xml:lang) ge 1) then concat(' [', $node//t:language[@ident = $anchornode/@xml:lang], ']') else ()
+let $wit :=  if ($anchornode/name() = 'witness' and $anchornode[not(@type = 'external')] and not($anchornode/text()))
+        then
+            (
+            let $filename := if (contains($anchornode/@corresp, '#')) then
+                substring-before($anchornode/@corresp, '#')
+            else
+                $anchornode/@corresp
+            let $file := collection('/db/apps/BetMasData/')/id($filename)
+            return
+                ($file//t:msIdentifier/t:idno)
+            )
+        else
+            ()
+let $text := if ($anchornode//text()) then $anchornode//text() else if ($wit) then string($wit) else substring-after($corresp, '#')
 return
 ($prefix,
-<ref xmlns="http://www.tei-c.org/ns/1.0" target="/{$c}">{titles:printTitleID($c)}</ref>)
+<ref xmlns="http://www.tei-c.org/ns/1.0" target="https://betamasaheft.eu/{$node/ancestor-or-self::t:TEI/@xml:id}#{$anchor}">{$text}</ref>)
 };
 declare function expand:biblCorresp($corresp, $node){
-<note xmlns="http://www.tei-c.org/ns/1.0" type='about'>(about: {
-if(contains($corresp, '\s')) then for $corr in tokenize($corresp, '\s') return expand:biblCorrTok($corr, $node) else expand:biblCorrTok($corresp, $node)
-})</note>
+let $string := normalize-space($corresp) return
+<note xmlns="http://www.tei-c.org/ns/1.0" type='about'>about {
+if(contains($string, ' ')) then for $corr at $p in tokenize($string, ' ') return
+(expand:biblCorrTok($corr, $node), if ($p = count(tokenize($string, ' '))) then
+            ()
+        else
+            ', ')
+else expand:biblCorrTok($corresp, $node)
+}</note>
 };
+
+declare function expand:printTitleMainID($id)
+   {if (matches($id, 'wd:Q\d+') or starts-with($id, 'gn:') or starts-with($id, 'pleiades:')) then
+           (titles:decidePlaceNameSource($id))
+(:           because wikidata identifiers are not speaking, the result of this operation is that the
+eventually added result is added to the place list names:)
+       else (: always look at the root of the given node parameter of the function and then switch :)
+           let $mainID := if (contains($id, '#'))  then substring-before($id, '#') else $id
+           let $resource := collection('/db/apps/BetMasData')//t:TEI[@xml:id = $mainID]
+           return
+                   titles:switcher($resource/@type, $resource)
+   };

--- a/db/apps/BetMasWeb/modules/generateFormattedBibliography.xqm
+++ b/db/apps/BetMasWeb/modules/generateFormattedBibliography.xqm
@@ -1,0 +1,143 @@
+xquery version "3.1";
+
+module namespace gfb = "https://www.betamasaheft.uni-hamburg.de/BetMas/gfb";
+import module namespace http = "http://expath.org/ns/http-client";
+declare namespace b = "betmas.biblio";
+declare namespace t = "http://www.tei-c.org/ns/1.0";
+declare option exist:serialize "method=xml media-type=text/xml indent=yes";
+
+declare variable $gfb:ethiostudies := 'https://api.zotero.org/groups/358366/items' ;
+
+(:   NEEDS POSTPROCESSING: THE ZOTERO OUTPUT as ESCAPED HTML
+
+replace &lt;i&gt; and &lt;/i&gt; with proper tags:)
+
+declare function gfb:unescape($cit as xs:string) as xs:string {
+    let $step1 := replace($cit, "&lt;", "<")
+    let $step2 := replace($step1, "&gt;", ">")
+    let $step3 := replace($step2, "&amp;#60;", "<")
+    let $step4 := replace($step3, "&amp;#62;", ">")
+    let $step5 := replace($step4, "&#60;", "<")
+    let $step6 := replace($step5, "&#62;", ">")
+    let $step7 := replace($step6, "<[^>]+>", "")
+    return normalize-space($step7)
+};
+
+declare function gfb:zot($c) {
+    let $xml-url-formattedBiblio := concat($gfb:ethiostudies,'?tag=', $c, '&amp;format=bib&amp;locale=en-GB&amp;style=hiob-ludolf-centre-for-ethiopian-studies-with-url-doi&amp;linkwrap=1')
+(:    let $log := util:log('INFO', $xml-url-formattedBiblio):)
+   let $data := try{let $request := <http:request href="{xs:anyURI($xml-url-formattedBiblio)}" method="GET"/>
+                               return http:send-request($request)[2]} catch *{$err:description}
+    let $log2 := util:log('INFO', $data)
+    let $datawithlink := $data//*:div[@class = 'csl-entry']
+    return
+        $datawithlink
+};
+
+declare function gfb:shortCit($c){
+ let $xml-url := concat($gfb:ethiostudies,'?tag=', $c, '&amp;include=citation&amp;style=hiob-ludolf-centre-for-ethiopian-studies-with-url-doi&amp;locale=en-GB')
+ let $log := util:log('INFO', $xml-url)
+            let $req :=
+            <http:request
+                http-version="1.1"
+                href="{xs:anyURI($xml-url)}"
+                method="GET">
+            </http:request>
+
+            let $zoteroApiResponse := http:send-request($req)[2]
+            let $decodedzoteroApiResponse := util:base64-decode($zoteroApiResponse)
+            let $parseedZoteroApiResponse := parse-json($decodedzoteroApiResponse)
+ let $replaced := replace($parseedZoteroApiResponse?*?citation, '&lt;', '<') 
+                     => replace('&gt;', '>')                     
+  return
+    $replaced
+                };
+
+declare function gfb:updateentry($ref){
+<entry xmlns="betmas.biblio" id="{$ref}">
+     <citation>{ try{gfb:shortCit($ref)} catch * {util:log('INFO', ($ref, $err:description))}}</citation>
+      <reference>{try{gfb:zot($ref)} catch * {util:log('INFO', ($ref, $err:description))} }</reference>
+ </entry>
+};
+
+declare function gfb:entry($cit, $ref){
+<entry xmlns="betmas.biblio" id="{$ref}">
+     <citation>{gfb:unescape($cit)}</citation>
+      <reference>{try{gfb:zot($ref)} catch * {util:log('INFO', ($ref, $err:description))} }</reference>
+ </entry>
+};
+
+
+(: given a collection parses all the ptr/@target and makes a bibliography.xml file with all the results of consecutive iterative requests:)
+declare function gfb:updateBib($context) {
+let $bibliography := doc('/db/apps/lists/bibliography.xml')/b:bibliography
+let $ptrs := collection("/db/apps/BetMasData")//t:bibl/t:ptr[starts-with(@target, 'bm:')]
+let $citations := distinct-values($ptrs/@target)
+let $cleancitations := for $c in $citations return replace($c, '\s+', '')
+ for $rawc in $cleancitations
+(: let $testrawc := util:log('INFO', $rawc):)
+let $match := $bibliography//b:entry[@id=$rawc]
+(: let $testmatch := util:log('INFO', $match):)
+ return
+ if (count($match) ge 1)
+ then ((:update the entry:)
+ util:log('INFO', ('entry for ' || $rawc || 'already exists'))
+ ) 
+ else 
+ let $test := util:log('INFO', ($rawc || ' is not in bibliography, adding entry '))
+(: let $total := util:log('INFO', $bibliography/b:total):)
+ let $entry := gfb:updateentry($rawc)
+ 
+let $update := if($entry/b:citation[not(text())] or $entry/b:reference[not(text())]) then util:log('WARN', $entry) else update insert $entry into $bibliography/b:entries
+let $updatetotal := update value $bibliography/b:total with count($cleancitations)
+(: add the entry:)
+return
+util:log('INFO', ('added entry for ' || $rawc))
+
+};
+
+(: given a collection parses all the ptr/@target and makes a bibliography.xml file with all the results of consecutive iterative requests:)
+declare function gfb:makeBib($collection) {
+let $ptrs := $collection//t:bibl/t:ptr[starts-with(@target, 'bm:')]
+let $citations := distinct-values($ptrs/@target)
+let $cleancitations := for $c in $citations return replace($c, '\s+', '')
+let $bibliography :=
+<bibliography
+    xmlns="betmas.biblio"><total>{count($citations)}</total>
+    <entries>{
+            for $rawc in $cleancitations
+            let $c := replace($rawc, '\s', '') 
+            let $shortCit := try{gfb:shortCit($c)} catch * {util:log('INFO', ($c, $err:description))}
+               group by $shortCit
+                order by $shortCit
+            return
+                if ($shortCit = '' or $shortCit = ' ') then
+                    for $sameCit in $rawc
+                    let $cit := "EMPTY! WRONG POINTER!"
+                    return
+                        gfb:entry($cit, $sameCit)
+                else
+                    if (count($c) gt 1) then
+                        for $sameCit at $p in $rawc
+                        let $letters := ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'l', 'm', 'n', 'o')
+                        let $cit := $shortCit||$letters[$p]
+                        return
+                        gfb:entry($cit, $sameCit)
+                else
+                        for $sameCit in $rawc
+                        return
+                        gfb:entry($shortCit, $sameCit)
+        }
+    </entries>
+</bibliography>
+
+
+
+let $store:=    xmldb:store('/db/apps/lists', 'bibliography.xml', $bibliography)
+let $stored:= '/db/apps/lists/bibliography.xml'
+let $permission := (sm:chgrp($stored, 'Cataloguers'), sm:chmod($stored, 'rwxrwxrwx'))  
+let $message :='stored ' || $stored
+return 
+util:log('INFO', $message)
+};
+

--- a/db/apps/BetMasWeb/modules/titlesData.xqm
+++ b/db/apps/BetMasWeb/modules/titlesData.xqm
@@ -1,0 +1,612 @@
+xquery version "3.1" encoding "UTF-8";
+
+(:~
+ : Titles for RAW (unexpanded) source data — used by the expansion pipeline
+ : (expand.xqm) and eventually gitsync. Ported from the legacy app
+ : (/db/apps/BetMas/modules/titles.xqm, authoritative as of 2025-11) so that
+ : expansion no longer depends on the legacy app.
+ : Distinct from titles.xqm (web/dts variant) and exptit.xqm (expanded data).
+ :)
+module namespace titles="https://www.betamasaheft.uni-hamburg.de/BetMas/titles";
+declare namespace t="http://www.tei-c.org/ns/1.0";
+declare namespace http = "http://expath.org/ns/http-client";
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+declare namespace sparql = "http://www.w3.org/2005/sparql-results#";
+declare namespace feed = "http://www.w3.org/2005/Atom";
+import module namespace config="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+import module namespace console="http://exist-db.org/xquery/console";
+import module namespace hc = "http://expath.org/ns/http-client";
+(: these lists are separately indexed here in the app with the collection.xconf for BetMas :)
+declare variable $titles:placeNamesList := doc('/db/apps/lists/placeNamesLabels.xml');
+declare variable $titles:institutionsList := doc('/db/apps/lists/institutions.xml');
+declare variable $titles:persNamesList := doc('/db/apps/lists/persNamesLabels.xml');
+declare variable $titles:TUList := doc('/db/apps/lists/textpartstitles.xml');
+declare variable $titles:deleted := doc('/db/apps/lists/deleted.xml');
+
+declare variable $titles:collection-root := collection($config:bmdata-root);
+declare variable $titles:collection-rootPl := collection(concat($config:bmdata-root, '/places'));
+
+(:establishes the different rules and priority to print a title referring to a record:)
+declare function titles:printTitle($node as element()) {
+(:always look at the root of the given node parameter of the function and then switch :)
+   let $resource := root($node)
+   return
+   titles:switcher($resource//t:TEI/@type, $resource)
+   };
+
+
+(:looks for different possible locations of anchor and where to pick the correct label:)
+declare function titles:printSubtitle($node as node(), $SUBid as xs:string) as xs:string {
+    if( starts-with($SUBid, 'tr')) then 'transformation ' ||  $SUBid
+else if( starts-with($SUBid, 'Uni')) then $SUBid
+else
+    let $item := $node//id($SUBid)
+    return
+       if ($item/name() = 'title') then
+             (string($item/@xml:lang) || (if($item/text()) then $item/text() else ' ... empty, sorry!'))
+        else
+        if ($item/name() = 'persName') then
+
+            (let $r := root($item)
+            return
+            if($r//t:persName[@type eq  'normalized'][contains(@corresp,$SUBid)])
+            then string-join($r//t:persName[@type eq  'normalized'][contains(@corresp,$SUBid)]//text(), '')
+            else normalize-space(string-join($item, ''))
+            )
+        else if ($item/name() = 'msItem') then
+            (if ($item/t:title/@ref)
+                then
+                    (titles:printTitleID(string($item/t:title/@ref)) || ' (in ' || $SUBid || ')')
+                else
+                    normalize-space(string-join(titles:tei2string($item/t:title), ''))
+                    )
+            else if ($item/t:label) then
+                let $sameAs := if ($item/@corresp) then (' (same as ' ||string($item/@corresp) || ')') else ()
+                return
+                   (normalize-space(string-join(titles:tei2string($item/t:label), '')) || $sameAs)
+            else if ($item[not(t:label)]/@corresp) then
+                   normalize-space(string-join(titles:printTitleID($item/@corresp), ''))
+            else if (matches($SUBid, '^a\d+$'))  then '  additio ' || $SUBid
+            else if ($item/t:desc) then
+                    (titles:printTitleID(string($item/t:desc/@type)) || ' ' || $SUBid)
+            else if (($item/@subtype eq  'Monday' or $item/@subtype eq  'Tuesday' or $item/@subtype eq  'Wednesday' or $item/@subtype eq  'Thursday' or $item/@subtype eq  'Friday' or $item/@subtype eq  'Saturday' or $item/@subtype eq  'Sunday'    )and not($item/node())) then
+                    (' for '|| $SUBid)
+            else if ($item/@subtype) then
+                    (titles:printTitleID(string($item/@subtype)) || ': ' || $SUBid)
+            else ($item/name() || ' ' || $SUBid)
+};
+
+(:this is now a switch function, deciding if to go ahead with simple print title or subtitles:)
+declare
+%test:arg('id', 'sdc:UniCont1') %test:assertEquals('La Synthaxe du Codex UniCont1')
+%test:arg('id', 'LIT2317Senodo#') %test:assertEquals('Senodos')
+%test:arg('id', '#') %test:assertEquals('&lt;span class="w3-tag w3-red"&gt;no item yet with id #&lt;/span&gt;')
+%test:arg('id', '') %test:assertEquals('&lt;span class="w3-tag w3-red"&gt;no id&lt;/span&gt;')
+%test:arg('id', 'BNFet32') %test:assertEquals('Paris, Bibliothèque nationale de France, BnF Éthiopien 32')
+%test:arg('id', 'LIT1367Exodus') %test:assertEquals('Exodus')
+%test:arg('id', 'PRS11160HabtaS') %test:assertEquals(' Habta Śǝllāse')
+%test:arg('id', 'LOC1001Aallee') %test:assertEquals('Aallee')
+%test:arg('id', 'BNFet32#a2') %test:assertEquals('Paris, Bibliothèque nationale de France, BnF Éthiopien 32, Donation Note a2')
+%test:arg('id', 'BNFet32#e1') %test:assertEquals('Paris, Bibliothèque nationale de France, BnF Éthiopien 32, no id e1')
+%test:arg('id', 'LIT1367Exodus#Ex1') %test:assertEquals('Exodus, Exodus 1')
+%test:arg('id', 'PRS5684JesusCh#n2') %test:assertEquals('Jesus Christ, Krǝstos')
+function titles:printTitleID($id as xs:string)
+{ if ($titles:deleted//t:item[.=$id]) then
+      let $del := $titles:deleted//t:item[.=$id]
+      let $formerly := $titles:collection-root//t:relation[@name eq 'betmas:formerlyAlsoListedAs'][@passive eq $id]
+              return
+              if($formerly) then
+                titles:printTitleID($formerly/@active) || ' [now '||string($formerly/@active)||', formerly also listed as '||$id||', which was requested here but has been deleted on '||string($del/@change)||']'
+                else $id || ' was permanently deleted'
+   else if (starts-with($id, 'sdc:')) then 'La Synthaxe du Codex ' || substring-after($id, 'sdc:' )
+    (: another hack for things like ref="#" :)
+    else if ($id = '#') then  'no item yet with id ' || $id
+    (: hack to avoid the bad usage of # at the end of an id like <title type="complete" ref="LIT2317Senodo#" xml:lang="gez"> :)
+    else if ($titles:TUList//t:item[@corresp eq  $id]) then ($titles:TUList//t:item[@corresp eq  $id][1]/node())
+    else if ($titles:persNamesList//t:item[@corresp eq  $id]) then ($titles:persNamesList//t:item[@corresp eq  $id][1]/node())
+    else if (ends-with($id, '#')) then (
+                                let $newid := replace($id, '#', '')
+                                return titles:printTitleID($newid) )
+    else if (matches($id, 'wd:Q\d+') or starts-with($id, 'gn:') or starts-with($id, 'pleiades:'))
+            then titles:decidePlaceNameSource($id)
+    (: if the id has a subid, than split it :)
+    else if (contains($id, '#')) then
+    (   let $mainID := substring-before($id, '#')
+        let $SUBid := substring-after($id, '#')
+        let $node := $titles:collection-root//id($mainID)
+        return
+            if($node) then(
+             if (starts-with($SUBid, 't')) then
+                    (let $subtitles:=$node//t:title[contains(@corresp, $SUBid)]
+                       let $subtitlemain := $subtitles[@type eq  'main']/text()
+                       let $subtitlenorm := $subtitles[@type eq  'normalized']/text()
+                         let $tit := $node//t:title[@xml:id = $SUBid]
+                        return
+                             if ($subtitlemain) then $subtitlemain
+                            else if ($subtitlenorm) then $subtitlenorm
+                            else $tit/text()
+                 )
+            else
+(:            format the title, add it to the list and pass again to this function, which will have something to match now:)
+                (let $subtitle := titles:printSubtitle($node, $SUBid)
+                 let $name := (titles:printTitleMainID($mainID)|| ': '||$subtitle)
+                 let $addit := titles:updateTUList($name, $id)
+                    return
+                        titles:printTitleID($id)
+                )
+    )
+    else if ($id = '') then  '?'
+    (: if no node could be found with the main id, that has a problem :)
+     else
+        ( 'No item: ' || $mainID
+            || ', could not check for ' || $SUBid
+        )
+    )
+       (: if not, procede to main title printing :)
+    else
+        titles:printTitleMainID($id)
+};
+
+
+declare function titles:printTitleMainID($id as xs:string, $c)
+   {if (matches($id, 'wd:Q\d+') or starts-with($id, 'gn:') or starts-with($id, 'pleiades:')) then
+           (titles:decidePlaceNameSource($id))
+(:           because wikidata identifiers are not speaking, the result of this operation is that the
+eventually added result is added to the place list names:)
+       else (: always look at the root of the given node parameter of the function and then switch :)
+           let $mainID := if (contains($id, '#'))  then substring-before($id, '#') else $id
+           let $resource := collection($c)//t:TEI[@xml:id = $mainID]
+           return
+               if (count($resource) = 0) then
+            'No item: ' || $id
+               else if (count($resource) > 1) then
+            'More than 1 ' || $id
+               else
+                   titles:switcher($resource/@type, $resource)
+   };
+
+
+
+declare
+%test:arg('id', 'BNFet32') %test:assertEquals('Paris, Bibliothèque nationale de France, BnF Éthiopien 32')
+%test:arg('id', 'LIT2317Senodo') %test:assertEquals('Senodos')
+%test:arg('id', 'LIT1367Exodus') %test:assertEquals('Exodus')
+%test:arg('id', 'PRS11160HabtaS') %test:assertEquals(' Habta Śǝllāse')
+%test:arg('id', 'LOC1001Aallee') %test:assertEquals('Aallee')
+function titles:printTitleMainID($id as xs:string)
+   {
+       if (matches($id, 'wd:Q\d+') or starts-with($id, 'gn:') or starts-with($id, 'pleiades:'))
+    then
+           (titles:decidePlaceNameSource($id))
+    else (: always look at the root of the given node parameter of the function and then switch :)
+           let $mainID := if (contains($id, '#'))  then substring-before($id, '#') else $id
+    (:       let $catchID := collection($config:bmdata-root)/id($mainID):)
+           let $resource := collection($config:bmdata-root)//t:TEI[@xml:id = $mainID]
+           return
+               if (count($resource) = 0) then
+           'No item: ' || $id
+               else if (count($resource) > 1) then
+            'More than 1 ' || $id
+               else
+                   let $type := string($resource/@type)
+                   return
+                titles:switcher($type, $resource)
+   };
+
+   declare function titles:switcher($type, $resource){
+  (: let $test := console:log(string-join($resource/ancestor-or-self::t:TEI/@xml:id, ' '))
+   return:)
+switch($type)
+            case "mss"
+                    return
+                     titles:manuscriptLabelFormatter($resource)
+             case "place"  return  titles:placeNameSelector($resource)
+             case "ins" return  titles:placeNameSelector($resource)
+            case "pers"  return titles:decidepersNameSource($resource, $resource/ancestor-or-self::t:TEI/@xml:id)
+            case "work"  return titles:decideTUSource($resource, $resource/ancestor-or-self::t:TEI/@xml:id)
+            case "nar"  return titles:decideTUSource($resource, $resource/ancestor-or-self::t:TEI/@xml:id)
+            case "studies"  return titles:decideTUSource($resource, $resource/ancestor-or-self::t:TEI/@xml:id)
+(:            this should do also auths:)
+            default return $resource//t:titleStmt/t:title[1]/text()
+};
+
+
+declare function titles:manuscriptLabelFormatter($resource) as xs:string {
+   if ($resource//objectDesc[@form eq  'Inscription'])
+       then ($resource//t:msIdentifier/t:idno/text())
+    else (if ($resource//t:repository/text() = 'Lost')
+          then ('Lost. ' || $resource//t:msIdentifier/t:idno/text())
+          else if ($resource//t:repository/@ref and $resource//t:msDesc/t:msIdentifier/t:idno/text())
+                then
+                    let $repoid := string(($resource//t:repository/@ref)[1])
+                    let $reponame := $titles:institutionsList/id($repoid)[1]/text()
+                    let $r := collection(concat($config:bmdata-root, '/institutions'))/id($repoid)
+                    let $repo := if ($r) then ($r) else 'No Institution record'
+                    let $repoPlace := if ($repo = 'No Institution record') then $repo else
+                                        (if ($repo[not(descendant::t:settlement)][not(descendant::t:country)]) then ('No location record')
+                                    else if ($repo//t:settlement[1]/@ref) then
+                                               let $plaID := string($repo//t:settlement[1]/@ref)
+                                               let $placeName := titles:decidePlaceNameSource($plaID)
+                                               return $placeName
+                                    else if ($repo//t:settlement[1]/text()) then $repo//t:settlement[1]/text()
+                                    else if ($repo//t:country/@ref) then
+                                               let $plaID := string($repo//t:country/@ref)
+                                               return
+                                                   titles:decidePlaceNameSource($plaID)
+                                    else if ($repo//t:country/text()) then
+                                               $repo//t:country/text()
+                                    else 'No location record'
+                                           )
+                    let $candidate := string-join($repoPlace, ' ') || ', ' || (
+                                     if ($repo = 'No Institution record') then $repo else ($reponame)
+                                     ) || ', ' ||
+                                           $resource//t:msDesc/t:msIdentifier/t:idno[1]/text()
+                    return normalize-space($candidate)
+        else 'no repository data for ' || string($resource/@xml:id)
+        )
+};
+
+
+declare function titles:placeNameSelector($resource as node()){
+      let $pl := $resource//t:place
+let $pnorm := $pl/t:placeName[@corresp eq  '#n1'][@type eq  'normalized']
+let $pEN := $pl/t:placeName[@corresp eq  '#n1'][@xml:lang='en']
+let $Maintitle := $pl/t:placeName[@type eq  'main']
+return
+ if ($Maintitle)
+                        then
+                            string-join($Maintitle/text())
+ else if ($pnorm)
+                        then
+                            normalize-space(string-join($pnorm/text(), ' '))
+ else if ($pEN)
+                        then
+                            normalize-space(string-join($pEN/text(), ' '))
+                        else
+                            if ($pl/t:placeName[@xml:id])
+                            then
+                            let $pn := $pl/t:placeName[@xml:id = 'n1']
+                            return
+                                normalize-space($pn/text())
+                            else
+                                if ($pl/t:placeName[text()][position() = 1]/text())
+                                then
+                                    normalize-space($pl/t:placeName[text()][position() = 1]/text())
+                                else
+                                    $resource//t:titleStmt/t:title[text()]/text()
+};
+
+declare function titles:persNameSelector($resource as node()){
+    let $p := $resource//t:person
+    let $pg := $resource//t:personGrp
+let $Maintitle := $p/t:persName[@type eq  'main']
+let $twonames:= $p/t:persName[@xml:id eq  'n1'][t:forename or t:surname]
+let $namegez := $p/t:persName[@corresp eq  '#n1'][@xml:lang = 'gez']
+let $nameennorm := $p/t:persName[@corresp eq  '#n1'][@xml:lang = 'en'][@type eq  'normalized']
+let $nameen := $p/t:persName[@corresp eq  '#n1'][@xml:lang = 'en']
+let $nameOthers := $p/t:persName[@corresp eq  '#n1'][@xml:lang[not(. = 'en')][not(. = 'gez')]]
+let $group := $pg/t:persName
+let $groupgez := $pg/t:persName[@corresp eq  '#n1'][@xml:lang = 'gez']
+let $groupennorm := $pg/t:persName[@corresp eq  '#n1'][@xml:lang = 'en'][@type eq  'normalized']
+
+return
+ (:            first check for persons with two names:)
+                        if ($twonames) then
+                            (
+                            if ($namegez)
+                            then
+                                ($namegez/t:forename/text()
+                                || ' ' || $namegez/t:surname/text())
+
+
+                            else
+                                if ($nameennorm)
+                                then
+                                    ($nameennorm/t:forename/text()
+                                    || ' ' || $nameennorm/t:surname/text())
+                             else
+                                if ($nameOthers)
+                                then
+                                    ($nameOthers[1]/t:forename/text()
+                                    || ' ' || $nameOthers[1]/t:surname/text())
+
+                                else
+                                    if ($resource//t:person/t:persName[@xml:id])
+                                    then
+                                    let $name := $resource//t:person/t:persName[@xml:id = 'n1']
+                                    return
+                                        ($name/t:forename/text()
+                                        || ' '
+                                        || $name/t:surname/text())
+
+                                    else
+                                        ($p/t:persName[position() = 1]/t:forename[1]/text() || ' '
+                                        || $p/t:persName[position() = 1]/t:surname[1]/text()))
+
+                            (:       then check if it is a personGrp:)
+                        else
+                            if ($group) then
+                                (
+                                if ($groupgez)
+                                then
+                                    $groupgez/text()
+
+
+                                else
+                                    if ($pg/t:persName[t:orgName])
+                                    then
+                                        let $gname:=$pg/t:persName[@xml:id = 'n1']
+                                        return $gname/t:orgName/text()
+
+
+                                    else
+                                        if ($groupennorm)
+                                        then
+                                            $groupennorm
+
+                                        else
+                                            if ($pg/t:persName[@xml:id])
+                                            then
+                                                let $gname:=$pg/t:persName[@xml:id = 'n1']
+                                                return string-join($gname/text())
+
+                                            else
+                                                ($pg/t:persName[position() = 1]//text()))
+
+                                (:       otherways is just a normal person:)
+                                 else
+                            if ($Maintitle)
+                        then
+                            string-join($Maintitle/text())
+                            else
+                                (
+                                if ($namegez)
+                                then
+                                    string-join($namegez//text())
+
+                                else
+                                    if ($nameennorm)
+                                    then
+                                        string-join($nameennorm//text())
+
+                                    else
+                                        if ($nameen)
+                                        then
+                                            string-join($nameen//text())
+                                    else
+                                      if ($nameOthers)
+                                        then
+                                    string-join($nameOthers[1]/text())
+
+
+                                        else
+                                            if ($p/t:persName[@xml:id])
+                                            then
+                                                let $name := $p/t:persName[@xml:id = 'n1']
+                                                return string-join($name//text())
+
+                                            else
+                                                string-join($p/t:persName[position() = 1][text()]//text())
+                                )
+};
+
+declare function titles:worknarrTitleSelector($resource as node()){
+    let $W := $resource//t:titleStmt
+let $Maintitle := $W/t:title[@type eq  'main'][@corresp eq  '#t1'][text()]
+                    let $amarictitle := $W/t:title[@corresp eq  '#t1'][@xml:lang = 'am' or @xml:lang = 'ar']
+                    let $geztitle := $W/t:title[@corresp eq  '#t1'][@xml:lang = 'gez']
+                    let $entitle := $W/t:title[@corresp eq  '#t1'][@xml:lang = 'en']
+                    return
+                        if ($Maintitle)
+                        then
+                            titles:normalize($Maintitle[1])
+                        else
+                            if ($amarictitle)
+                            then
+                                titles:normalize($amarictitle[1])
+                            else
+                                if ($geztitle)
+                                then
+                                    titles:normalize($geztitle[1])
+                                else
+                                    if ($entitle)
+                                    then
+                                        titles:normalize($entitle[1])
+                                    else
+                                        if ($W/t:title[@xml:id])
+                                        then
+                                            let $tit := $W/t:title[@xml:id = 't1']
+                                            return titles:normalize($tit)
+                                        else
+                                            titles:normalize($W/t:title[1])
+};
+
+declare function titles:normalize($nodes){
+let $tostring := $nodes/string()
+return
+normalize-space(string-join($tostring))
+};
+
+declare function titles:decidePlName($plaID){
+    if (starts-with($plaID, 'wd:'))
+        then titles:getwikidataNames($plaID)
+    else if (starts-with($plaID, 'gn:'))
+        then titles:getGeoNames($plaID)
+    else
+        let $placefile := $titles:collection-rootPl/id($plaID)
+        return
+            titles:placeNameSelector($placefile[1])
+};
+
+(:Given an id, decides if it is one of BM or from another source and gets the name accordingly:)
+declare function titles:decidePlaceNameSource($pRef as xs:string){
+if ($titles:placeNamesList//t:item[@corresp =  $pRef])
+    then $titles:placeNamesList//t:item[@corresp = $pRef][1]/text()
+else if (starts-with($pRef, 'gn:')) then (
+        let $name := titles:getGeoNames($pRef)
+        let $addit := titles:updatePlaceList($name, $pRef)
+        return
+        titles:decidePlaceNameSource($pRef))
+else if (starts-with($pRef, 'pleiades:')) then (
+        let $name := titles:getPleiadesNames($pRef)
+        let $addit := titles:updatePlaceList($name, $pRef)
+        return
+            titles:decidePlaceNameSource($pRef))
+else if (matches($pRef, 'wd:Q\d+')) then (
+        let $name := titles:getwikidataNames($pRef)
+(:    let $test := console:log($name):)
+        let $addit := titles:updatePlaceList($name, $pRef)
+        return
+            titles:decidePlaceNameSource($pRef))
+else (
+    let $resource := $titles:collection-rootPl/id($pRef)
+    return titles:placeNameSelector($resource)
+    )
+};
+
+(:Given an id, decides if it is one of BM or from another source and gets the name accordingly:)
+declare function titles:decidepersNameSource($resource, $pRef as xs:string){
+if ($titles:persNamesList//t:item[@corresp eq  $pRef])
+    then $titles:persNamesList//t:item[@corresp eq  $pRef][1]/text()
+else if (matches($pRef, 'wd:Q\d+')) then (
+    let $name := titles:getwikidataNames($pRef)
+(:    let $test := console:log($name):)
+    let $addit := titles:updatePersList($name, $pRef)
+    return titles:decidepersNameSource($resource, $pRef)
+    )
+else
+  let $name := titles:persNameSelector($resource)
+  let $addit := titles:updatePersList($name, $pRef)
+  return titles:decidepersNameSource($resource, $pRef)
+};
+
+(:Given an id, decides if it is one of BM or from another source and gets the name accordingly:)
+declare function titles:decideTUSource($resource, $pRef as xs:string){
+if ($titles:TUList//t:item[@corresp eq  $pRef])
+    then $titles:TUList//t:item[@corresp eq  $pRef][1]/text()
+else
+  let $name := titles:worknarrTitleSelector($resource)
+  let $addit := titles:updateTUList($name, $pRef)
+  return titles:decideTUSource($resource, $pRef)
+};
+
+declare function titles:updatePlaceList($name, $pRef){
+let $_ := util:log('INFO', 'Updating placeNamesList with ' || $name || ': ' || $pRef)
+let $placeslist := $titles:placeNamesList//t:list
+return
+update insert <item
+xmlns="http://www.tei-c.org/ns/1.0"
+change="entryAddedAt{current-dateTime()}"
+corresp="{$pRef}">{$name}</item> into  $placeslist
+};
+
+declare function titles:updatePersList($name, $pRef){
+let $_ := util:log('INFO', 'Updating persNamesList with ' || $name || ': ' || $pRef)
+let $perslist := $titles:persNamesList//t:list
+return
+update insert <item
+xmlns="http://www.tei-c.org/ns/1.0"
+change="entryAddedAt{current-dateTime()}"
+corresp="{$pRef}">{$name}</item> into  $perslist
+};
+
+declare function titles:updateTUList($name, $pRef){
+let $_ := util:log('INFO', 'Updating TUList with ' || $name || ': ' || $pRef)
+let $TUList := $titles:TUList//t:list
+return
+update insert <item
+xmlns="http://www.tei-c.org/ns/1.0"
+change="entryAddedAt{current-dateTime()}"
+corresp="{$pRef}">{$name}</item> into  $TUList
+};
+
+declare function titles:request($request as element(http:request)) {
+	  let $_ := util:log("info", $request/@href)
+    let $response := http:send-request($request)
+    let $status-code := xs:integer($response[1]/@status)
+
+    return
+				if ($status-code = 429)
+				then
+						let $retry-after := ($response[1]/http:header[@name="Retry-After"], 1000)[1]
+						let $_ := util:log('INFO', '429 from ' || $request/@href || ', waiting ' || $retry-after || ' ms until retrying.')
+						let $_ := util:wait(xs:integer($retry-after))
+						return titles:request($request)
+			else if ($status-code >= 400)
+        then
+						let $_ := util:log(
+								'INFO',
+								"server connection failed: " || $response[1]/@message || " (" || $status-code || ")" || $response[1])
+						return error(
+								xs:QName("titles:connection-error"),
+								"server connection failed: " || $response[1]/@message || " (" || $status-code || ")" || $response[1])
+        else $response
+};
+
+declare function titles:getGeoNames ($string as xs:string){
+let $gnid:= substring-after($string, 'gn:')
+let $xml-url := concat('http://api.geonames.org/get?geonameId=',$gnid,'&amp;username=betamasaheft')
+let $data := try{let $request := <http:request href="{xs:anyURI($xml-url)}" method="GET"/>
+    return titles:request($request)[2]} catch *{$err:description}
+return
+if ($data//toponymName) then
+$data//toponymName/text()
+else 'no data from geonames'
+};
+
+declare function titles:getPleiadesNames($string as xs:string) {
+
+   let $plid := substring-after($string, 'pleiades:')
+   let $url := concat('https://pleiades.stoa.org/places/', $plid, '/atom')
+  let $request :=
+    <hc:request href="{$url}" method="GET">
+        <hc:header name="Connection" value="close"/>
+    </hc:request>
+let $title :=
+let $response := hc:send-request($request)
+let $response-head := $response[1]
+let $response-body := $response[2]
+return
+    $response-body//feed:title
+return string($title[1])
+};
+
+declare function titles:getwikidataNames($pRef as xs:string){
+let $pRef := substring-after($pRef, 'wd:')
+let $sparql := 'SELECT * WHERE {
+  wd:' || $pRef || ' rdfs:label ?label .
+  FILTER (langMatches( lang(?label), "EN" ) )
+}'
+
+
+let $query := 'https://query.wikidata.org/sparql?query='|| xmldb:encode-uri($sparql)
+
+let $req := try{let $request := <http:request href="{xs:anyURI($query)}" method="GET"><http:header name="User-Agent" value="betamasaheft.eu (info@betamasaheft.eu)"/></http:request>
+    return titles:request($request)[2]} catch * {$err:description}
+return
+$req//sparql:result/sparql:binding[@name eq "label"]/sparql:literal[@xml:lang='en']/text()
+};
+
+
+(:takes a node as argument and loops through each element it contains. if it matches one of the definitions it does that, otherways checkes inside it. This actually reproduces the logic of the apply-templates function in  xslt:)
+declare function titles:tei2string($nodes as node()*) {
+
+    for $node in $nodes
+    return
+        typeswitch ($node)
+        case element(t:title)
+                return
+                   try{ titles:printTitleMainID($node/@ref) } catch * {console:log($node)}
+        case element(t:persName)
+                return
+                    titles:printTitleMainID($node/@ref)
+         case element(t:placeName)
+                return
+                    titles:printTitleMainID($node/@ref)
+            case element()
+                return
+                    titles:tei2string($node/node())
+            default
+                return
+                    $node
+};


### PR DESCRIPTION
Port the authoritative legacy expansion chain into BetMasWeb, where all active code should live (see #49):

- `expand.xqm`: legacy content (incl. 2025-10/11 fixes), imports repointed; replaces the Web copy broken since f21b820 (XQST0059 namespace mismatch)
- `titlesData.xqm`: new home of the raw-data titles module (distinct from titles.xqm web/dts variant and exptit.xqm)
- `generateFormattedBibliography.xqm`: copied, had no Web counterpart
- `makeExpand.xql:` import repointed to BetMasWeb