### PR TITLE
fix(viewItem): strip canonical BMurl in URI2ID, emit appUrl-prefixed …

### DIFF
--- a/db/apps/BetMasWeb/modules/item.xqm
+++ b/db/apps/BetMasWeb/modules/item.xqm
@@ -513,7 +513,7 @@ declare function item2:AdminLocTable($adminLoc as element()*){
                                            <td>{if($s/@type) then exptit:printTitleID($s/@type/data()) else $s/local-name()}</td>
                                            <td>{
                                            if($s/@ref) then
-                                           (<a target="_blank" href="{$config:appUrl}/{if(starts-with($s/@ref, $config:appUrl)) then substring-after($s/@ref, concat($config:appUrl, '/')) else $s/@ref}">{if ($s/text()) then $s/text() else viewItem:namedEntityPlace($s)}</a>,
+                                           (<a target="_blank" href="{$config:appUrl}/{if(starts-with($s/@ref, $config:BMurl)) then substring-after($s/@ref, $config:BMurl) else $s/@ref}">{if ($s/text()) then $s/text() else viewItem:namedEntityPlace($s)}</a>,
                                            <a xmlns="http://www.w3.org/1999/xhtml"
                                            id="{generate-id($s)}Ent{$s/@ref}relations"> <i class="fa fa-hand-o-left"/>
                                            </a>)
@@ -1349,7 +1349,9 @@ let $witnesses := $apprest:collection-rootMS//t:title[contains(@ref, $c)][parent
 let $countwitnesses := for $wit in $witnesses
  let $wid :=  string(root($wit)/t:TEI/@xml:id )
  group by $id := $wid return $id
-let $tit := exptit:printTitleID($c)
+(: relation values carry the canonical prefix; the title lookup and app links need the bare id :)
+let $cid := if (starts-with($c, $config:BMurl)) then substring-after($c, $config:BMurl) else $c
+let $tit := exptit:printTitleID($cid)
 let $subids := for $subid in $work//t:div[@type eq 'textpart'][@corresp eq $c]/@xml:id return $id || '#' || string($subid)
 let $stringsubids:=string-join($subids, ',')
 
@@ -1372,7 +1374,7 @@ let $stringsubids:=string-join($subids, ',')
 return <p><a target="_blank" href="{$config:appUrl}/compare?workid={$stringsubids},{$c}">Click to compare manuscripts of both {$stringsubids} and {$c}.</a></p> else ()}
 </div>
 ) else <p>
-<a target="_blank" href="{$config:appUrl}/{$c}">{$tit}</a> is listed also as {$c}, but not recorded with this reference in any manuscript at the moment.</p>
+<a target="_blank" href="{$config:appUrl}/{$cid}">{$tit}</a> is listed also as {$c}, but not recorded with this reference in any manuscript at the moment.</p>
 ) else ()
 }
     </span> </div>

--- a/db/apps/BetMasWeb/modules/queries.xqm
+++ b/db/apps/BetMasWeb/modules/queries.xqm
@@ -4142,7 +4142,11 @@ declare function q:selectors($nodeName, $nodes, $type) {
 
                         for $n in $nodes[. != ''][. != ' ']
                         (:                        let $t := util:log('info', $n):)
-                        let $id := if (starts-with($n, $config:appUrl)) then
+                        (: the data carries the canonical prefix ($config:BMurl),
+                         : not the host this instance is served from :)
+                        let $id := if (starts-with($n, $config:BMurl)) then
+                            substring-after($n, $config:BMurl)
+                        else if ($config:appUrl != '' and starts-with($n, $config:appUrl)) then
                             substring-after($n, ($config:appUrl || '/'))
                         else
                             $n

--- a/db/apps/BetMasWeb/modules/viewItem.xqm
+++ b/db/apps/BetMasWeb/modules/viewItem.xqm
@@ -722,7 +722,7 @@ declare %private function viewItem:worktitle($t) {
                     (),
                 if ($t/@ref) then
                     <a
-                        href="/{viewItem:URI2ID($t/@ref)}"
+                        href="{$config:appUrl}/{viewItem:URI2ID($t/@ref)}"
                         target="_blank">{$t/text()}</a>
                 else
                     viewItem:TEI2HTML($t/node()),
@@ -748,7 +748,7 @@ declare %private function viewItem:placename($name) {
                     (),
                 if ($name/@ref) then
                     <a
-                        href="/{viewItem:URI2ID($name/@ref)}"
+                        href="{$config:appUrl}/{viewItem:URI2ID($name/@ref)}"
                         target="_blank">{$name/text()}</a>
                 else
                     viewItem:TEI2HTML($name/node()),
@@ -784,7 +784,7 @@ declare %private function viewItem:persname($name) {
                     (),
                 if ($name/@ref) then
                     <a
-                        href="/{viewItem:URI2ID($name/@ref)}"
+                        href="{$config:appUrl}/{viewItem:URI2ID($name/@ref)}"
                         target="_blank">{$name/text()}</a>
                 else
                     viewItem:TEI2HTML($name/node()),
@@ -845,7 +845,11 @@ declare %private function viewItem:workAuthorList($parentname, $p, $a) {
 declare %private function viewItem:URI2ID($string) {
     let $string := normalize-space(string-join($string)) => replace('\s', '')
     return
-        if (starts-with($string, $config:appUrl)) then
+        (: the expanded data carries the canonical prefix ($expand:BMurl),
+         : not the host this instance is served from :)
+        if (starts-with($string, $config:BMurl)) then
+            substring-after($string, $config:BMurl)
+        else if ($config:appUrl != '' and starts-with($string, $config:appUrl)) then
             substring-after($string, ($config:appUrl || '/'))
         else
             $string
@@ -1544,7 +1548,7 @@ declare %private function viewItem:namedEntityTitle($entity) {
   if((count($entity/ancestor::t:msItem) gt 2) and (count($entity/ancestor::t:TEI//t:msItem) gt 100)) then
    
    (string-join($entity//text()),
-    if (matches($entity/@ref, 'LIT')) then <a  xmlns="http://www.w3.org/1999/xhtml" href="/{viewItem:URI2ID($entity/@ref)}">({viewItem:cae($entity)})</a>
+    if (matches($entity/@ref, 'LIT')) then <a  xmlns="http://www.w3.org/1999/xhtml" href="{$config:appUrl}/{viewItem:URI2ID($entity/@ref)}">({viewItem:cae($entity)})</a>
     else
         ()
     )
@@ -1552,7 +1556,7 @@ declare %private function viewItem:namedEntityTitle($entity) {
     (
     <a target="_blank"
         xmlns="http://www.w3.org/1999/xhtml"
-        href="/{viewItem:URI2ID($entity/@ref)}">{viewItem:TEI2HTML($entity/node())}</a>,
+        href="{$config:appUrl}/{viewItem:URI2ID($entity/@ref)}">{viewItem:TEI2HTML($entity/node())}</a>,
     if (matches($entity/@ref, 'LIT')) then
         (' (' || viewItem:cae($entity) || ')')
     else


### PR DESCRIPTION
…hrefs

`viewItem:URI2ID` stripped `$config:appUrl`, but the expanded data carries the canonical prefix (`$expand:BMurl`). The two only coincide on production; in the container the function returned the full canonical URL and callers rendered `href="/https://betamasaheft.eu/..."` . With an empty `appUrl `the old code instead produced protocol-relative `//betamasaheft.eu/...` hrefs.

- `URI2ID`: strip `$config:BMurl` first, fall back to a non-empty `appUrl`
- prefix the five root-absolute `href="/{…}"` call sites with `$config:appUrl` so links keep the app base path when the app is not served at `/`

`work-title` hrefs now resolve `302`->`200~ and betmas-e2e `manuscripts-view.cy.js` passes 3/3, including the link-follow test that had been split to `@production-only`.

once we have fresh container here, the updated tests in BetaMasaheft/betmas-e2e#70 should pass.