### PR TITLE
Service integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 # Build artifacts
 /db/apps/*/build/*
 
+# Generated at first container start by BetMasInitInstance/finish.xq from
+# environment variables; must never be committed or baked into a xar
+/db/apps/BetMasWeb/services.xml
+
 # Ignore anything that's on the server but not in the mono repo
 
 # This is in the dillmann repo on github

--- a/db/apps/BetMasInitInstance/finish.xq
+++ b/db/apps/BetMasInitInstance/finish.xq
@@ -24,7 +24,7 @@ declare variable $loc:appUrl := "`{$app_url}`";
    environment is not yet set. :)
 let $services :=
     <services>{
-        for $env in ('COLLATEX_URL')
+        for $env in ('COLLATEX_URL', 'FUSEKI_URL')
         let $value := fn:environment-variable($env)
         where normalize-space($value) != ''
         return <service env="{$env}">{normalize-space($value)}</service>

--- a/db/apps/BetMasInitInstance/finish.xq
+++ b/db/apps/BetMasInitInstance/finish.xq
@@ -14,9 +14,30 @@ module namespace loc="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/loc";
 declare variable $loc:appUrl := "`{$app_url}`";
 ]``
 
+(: Capture external-service endpoint overrides while running as DBA:
+   fn:environment-variable is a DBA-only read in eXist, so request-time
+   code cannot see these. config:service-url() in BetMasWeb reads the
+   stored document instead and falls back to its default (the production
+   wiring) when a variable was not set. This must run here (stage-2
+   autodeploy, first container start) and not in BetMasWeb's own
+   post-install, which runs during the image build where the runtime
+   environment is not yet set. :)
+let $services :=
+    <services>{
+        for $env in ('COLLATEX_URL')
+        let $value := fn:environment-variable($env)
+        where normalize-space($value) != ''
+        return <service env="{$env}">{normalize-space($value)}</service>
+    }</services>
+
 let $_ := util:log('info', 'Storing ' || $app_url || ' as the root of the application.	')
 
 return xmldb:store('/db/apps/BetMasWeb/modules', 'loc.xqm', $loc_module),
+
+(: guest must be able to read but never write this document: it holds
+   URLs the server itself will POST to :)
+(xmldb:store('/db/apps/BetMasWeb', 'services.xml', $services),
+ sm:chmod(xs:anyURI('/db/apps/BetMasWeb/services.xml'), 'rw-r--r--')),
 
 (: Store tuttle configuration :)
 xmldb:store('/db/apps/tuttle/data', 'tuttle.xml', doc('./tuttle.xml')),

--- a/db/apps/BetMasWeb/build.xml
+++ b/db/apps/BetMasWeb/build.xml
@@ -5,6 +5,6 @@
     <property name="build.dir" value="build"/>
     <target name="xar">
         <mkdir dir="${build.dir}"/>
-        <zip basedir="." destfile="${build.dir}/${project.app}-${project.version}.xar" excludes="${build.dir}/*"/>
+        <zip basedir="." destfile="${build.dir}/${project.app}-${project.version}.xar" excludes="${build.dir}/*, services.xml"/>
     </target>
 </project>

--- a/db/apps/BetMasWeb/fuseki/fuseki.xqm
+++ b/db/apps/BetMasWeb/fuseki/fuseki.xqm
@@ -13,7 +13,16 @@ declare namespace sr = "http://www.w3.org/2005/sparql-results#";
 
 (:Assumes that Fuseki is running in Tomcat, and that Tomcat server.xml has been edited to run on port 8081, instead of 8080. :)
 (: Note: the version in BetMas had port 8081, in BetMasWeb 3030 :)
-declare variable $fusekisparql:port := 'http://localhost:3030/';
+(: Fuseki base URL (env: FUSEKI_URL, captured at instance initialisation —
+   see config:service-url). Must end with a slash: dataset names are
+   concatenated directly onto it.
+   NB this only relocates a *Fuseki* instance: the URLs built below are
+   dataset-scoped ({base}{dataset}/query, /update) and the results are
+   parsed as SPARQL XML. The QLever service (sparql-service repo) exposes
+   a different surface (GET /?query= on a single index), so migrating to
+   it means adapting this module, not just overriding the URL. :)
+declare variable $fusekisparql:port :=
+    config:service-url('FUSEKI_URL', 'http://localhost:3030/');
 
 
 (:~ given a SPARQL query this will pass it to the selected dataset  and return SPARQL Results in XML:)

--- a/db/apps/BetMasWeb/modules/config.xqm
+++ b/db/apps/BetMasWeb/modules/config.xqm
@@ -63,7 +63,7 @@ declare variable $config:BMurl := 'https://betamasaheft.eu/';
  : Resolve an external service endpoint. A deployment relocates a service
  : by setting the corresponding environment variable on the eXist process
  : (e.g. `docker run -e COLLATEX_URL=...`); betmas-init captures set
- : variables into modules/services.xml at instance initialisation, because
+ : variables into services.xml at the app root at instance initialisation, because
  : fn:environment-variable is a DBA-only read in eXist and request-time
  : code (running as guest) cannot see them. Falls back to the given
  : default (= production wiring) when the document or entry is missing.

--- a/db/apps/BetMasWeb/modules/config.xqm
+++ b/db/apps/BetMasWeb/modules/config.xqm
@@ -59,6 +59,33 @@ declare variable $config:baseURI := $config:appUrl || "/";
  :)
 declare variable $config:BMurl := 'https://betamasaheft.eu/';
 
+(:~
+ : Resolve an external service endpoint. A deployment relocates a service
+ : by setting the corresponding environment variable on the eXist process
+ : (e.g. `docker run -e COLLATEX_URL=...`); betmas-init captures set
+ : variables into modules/services.xml at instance initialisation, because
+ : fn:environment-variable is a DBA-only read in eXist and request-time
+ : code (running as guest) cannot see them. Falls back to the given
+ : default (= production wiring) when the document or entry is missing.
+ :)
+declare function config:service-url($env-name as xs:string, $default as xs:string) as xs:string {
+    try {
+        (doc('/db/apps/BetMasWeb/services.xml')
+            //service[@env eq $env-name][normalize-space(.) ne '']/string(),
+         $default)[1]
+    } catch * {
+        $default
+    }
+};
+
+(:~
+ : CollateX collation endpoint (env: COLLATEX_URL). The default is the
+ : servlet deployment on the production host; the containerised
+ : collatex-service serves the same API at http://<host>:17105/collate.
+ :)
+declare variable $config:collatexUrl :=
+    config:service-url('COLLATEX_URL', 'http://localhost:8081/collatex-servlet-1.7.1/collate');
+
 declare variable $config:DOI := '10.25592/BetaMasaheft';
 
 declare variable $config:response200 := <rest:response>

--- a/db/apps/BetMasWeb/newSearch.html
+++ b/db/apps/BetMasWeb/newSearch.html
@@ -124,7 +124,7 @@
                             <div class="w3-half w3-padding">
                                
                                     <div class="w3-container">
-                                        <input id="endpoint" value="/api/SPARQL/json" type="text" hidden="hidden"/>
+                                        <input id="endpoint" value="api/SPARQL/json" type="text" hidden="hidden"/>
                                         <button type="button" class="w3-button w3-red" onclick="exec()">
                                             Run your query (results with d3sparql.js)
                                         </button>

--- a/db/apps/BetMasWeb/resources/js/collatex.js
+++ b/db/apps/BetMasWeb/resources/js/collatex.js
@@ -31,7 +31,9 @@ console.log(dts)
 
 /*should also call dts directly to display passage which is being collated and created divs with that content beside the collation*/
 
-var apicall = '/api/collatex?format=json&dts=' + dts.join(',') + '&nU=' + nU.join(',')
+/* document-relative like the page's other assets, so the call stays under
+   the app base wherever the app is not served from the origin root */
+var apicall = 'api/collatex?format=json&dts=' + dts.join(',') + '&nU=' + nU.join(',')
 /*console.log('collating@!')*/
 var container = $('#collationResult')
 

--- a/db/apps/BetMasWeb/restviews/collatex.xqm
+++ b/db/apps/BetMasWeb/restviews/collatex.xqm
@@ -49,7 +49,7 @@ then (<info>please provide at least 2 dts URIs separated with comma</info>)  els
      let $req :=
         <http:request
         http-version="1.1"
-            href="{xs:anyURI('http://localhost:8081/collatex-servlet-1.7.1/collate')}"
+            href="{xs:anyURI($config:collatexUrl)}"
             method="POST">
             <http:header
                 name="Content-Type"

--- a/db/apps/BetMasWeb/sparql.html
+++ b/db/apps/BetMasWeb/sparql.html
@@ -9,7 +9,7 @@
         <div class="w3-half w3-padding">
         <form action="" class="w3-container">
             <div class="w3-container">
-                <input id="endpoint" value="/api/SPARQL/json" type="text" hidden="hidden"/>
+                <input id="endpoint" value="api/SPARQL/json" type="text" hidden="hidden"/>
                     <textarea class="w3-input w3-border" id="sparql" name="query" style="height:200px">
                     </textarea>
                         <br/>


### PR DESCRIPTION
Closes #96.

Makes external service endpoints configurable so a deployment can point BetMasWeb at services that no longer live on the production host — starting with the containerised CollateX — and fixes the client-side paths that only resolved when the app was served from the origin root.

- **Reachability (#96):** `collatex.js` used a root-absolute `/api/collatex` (only resolves when the app is served from the origin root) → now document-relative, like the page's other assets. `restviews/collatex.xqm` no longer hardcodes the servlet URL.
- **SPARQL endpoint:** `sparql.html` and `newSearch.html` embedded `value="/api/SPARQL/json"` in the hidden `#endpoint` input (feeds `d3sparql.query()`) → now relative `api/SPARQL/json`. Both pages are served shallow, so this resolves under the app base at any deployment.
- **`config:service-url($env, $default)`:** resolves an endpoint from an environment variable, falling back to the current production default — so **no behaviour change on production**. Adds `$config:collatexUrl` (`COLLATEX_URL`) and switches Fuseki to `FUSEKI_URL`.
- **Init capture:** `fn:environment-variable` is a DBA-only read in eXist, so request-time code (guest) can't see it. `BetMasInitInstance/finish.xq` captures set vars into `services.xml` at first container start — guest-readable but DBA-writable (it holds URLs the server itself POSTs to); gitignored and excluded from the xar.

**QLever note:** `FUSEKI_URL` only relocates a *Fuseki* instance. QLever exposes a different surface (single index, `GET /?query=`, JSON), so migrating to it means adapting `fuseki.xqm`, not overriding the URL.
