### PR TITLE
build(docker): add BetMasApi to the app image

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -7,6 +7,8 @@
 #
 # App sources still come from db/apps/ in this repo; they flip to the
 # standalone repos when those become canonical and the copies here freeze.
+# BetMasApi already lives only in its own repo, so it's fetched from there
+# now — same pattern the rest will move to.
 #
 # Local build (base from ghcr, or --build-arg BETMAS_DATA_IMAGE=betmas-data:local):
 #   docker build -f docker/app.Dockerfile -t betamasaheft:local .
@@ -14,7 +16,13 @@
 ARG BETMAS_DATA_IMAGE=ghcr.io/betamasaheft/betmas-data:latest
 ARG BUILDER_IMAGE=ghcr.io/eeditiones/builder:latest
 
+# BetMasApi is canonical in its own repo (never mirrored into db/apps/), so
+# it's fetched like a data.Dockerfile data package, not COPY'd from here.
+ARG BETMASAPI_REF=main
+
 FROM ${BUILDER_IMAGE} AS build
+
+ARG BETMASAPI_REF
 
 COPY db/apps/BetMasService /tmp/BetMasService
 COPY db/apps/BetMasWeb /tmp/BetMasWeb
@@ -24,13 +32,21 @@ COPY db/apps/BetMasInitInstance /tmp/BetMasInitInstance
 
 RUN mkdir /tmp/apps /tmp/stage-2
 
-# Numbered for autodeploy's lexicographic install order. 12- is reserved for
-# BetMasApi, which must follow BetMasWeb (its expath-pkg declares
-# betmasweb >= 0.1 and roaster >= 1.12.1 — the latter ships in the base).
+# Numbered for autodeploy's lexicographic install order. BetMasApi (12-)
+# must follow BetMasWeb (11-): its expath-pkg declares betmasweb >= 0.1 and
+# roaster >= 1.12.1 (the latter ships in the base).
 WORKDIR /tmp/BetMasService
 RUN jar cfM0 /tmp/apps/10-BetMasService.xar .
 WORKDIR /tmp/BetMasWeb
 RUN jar cfM0 /tmp/apps/11-BetMasWeb.xar .
+
+# BetMasApi ships its own expath ant build (zips with its own excludes:
+# test/, docker/, node_modules); build it instead of jar cfM0-ing the raw
+# checkout so we get the same xar its own CI produces.
+ADD https://github.com/BetaMasaheft/BetMasApi.git#${BETMASAPI_REF} /tmp/BetMasApi
+WORKDIR /tmp/BetMasApi
+RUN ant && mv build/BetMasApi-*.xar /tmp/apps/12-BetMasApi.xar
+
 WORKDIR /tmp/parser
 RUN jar cfM0 /tmp/apps/13-parser.xar .
 WORKDIR /tmp/BetMas
@@ -42,10 +58,12 @@ RUN jar cfM0 /tmp/stage-2/BetMasInitInstance.xar .
 
 FROM ${BETMAS_DATA_IMAGE}
 
+ARG BETMASAPI_REF
 ARG APP_COMMIT=unpinned
 LABEL org.opencontainers.image.source="https://github.com/BetaMasaheft/BetMas" \
-      org.opencontainers.image.description="BetaMasaheft app image: BetMasWeb + BetMasService + parser on the betmas-data base" \
-      eu.betamasaheft.ref.betmas=${APP_COMMIT}
+      org.opencontainers.image.description="BetaMasaheft app image: BetMasWeb + BetMasService + BetMasApi + parser on the betmas-data base" \
+      eu.betamasaheft.ref.betmas=${APP_COMMIT} \
+      eu.betamasaheft.ref.betmasapi=${BETMASAPI_REF}
 
 COPY --from=build /tmp/apps/*.xar /exist/autodeploy/
 


### PR DESCRIPTION
## Summary
Follow-up to #124 (data/app image split, merged). Fills the `12-` slot
reserved in `docker/app.Dockerfile` for BetMasApi.

- BetMasApi is standalone-canonical (never lived in `db/apps/`), so it's
  fetched the way `data.Dockerfile` fetches data repos —
  `ADD https://github.com/BetaMasaheft/BetMasApi.git#${BETMASAPI_REF}` —
  rather than copied from this repo.
- Built with BetMasApi's own `ant` xar task (its `build.xml` has its own
  excludes for `test/`, `docker/`, `node_modules`) instead of `jar cfM0`
  on the raw checkout, so the image ships the exact package its own CI
  produces.
- Installs at `12-BetMasApi.xar`, after BetMasWeb (`11-`): its
  `expath-pkg.xml` requires `betmasweb >= 0.1` and `roaster >= 1.12.1`,
  both already in the `betmas-data` base.
- `BETMASAPI_REF` (default `main`) is recorded as an
  `eu.betamasaheft.ref.betmasapi` OCI label, matching the data-repo
  provenance labels in `data.Dockerfile`.

## Test plan
- [x] Local build (`docker build -f docker/app.Dockerfile -t betamasaheft:local-api .`)
      — autodeploy log confirms BetMasApi's declared dependencies
      (betmasweb, roaster) resolved and it installed cleanly after
      BetMasWeb.
- [x] Ran the resulting image standalone: `GET /exist/apps/BetMasApi/api.json`
      returns 200 with all 102 declared paths (roaster router live);
      `GET /exist/apps/BetMasWeb/` still 200 (no regression to the base
      app). A bare-param `/api/SPARQL/json` 500 is the known pre-existing
      issue, not something this change introduces.
- [ ] Full e2e suite against this image once merged/published (blocked
      locally on Cypress test-user credentials this session doesn't have).

Refs #122