### PR TITLE
build(compose): nginx as sole entry point + full-profile services + Dillmann

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
   # `docker compose --profile full up`. No host ports - reached via
   # nginx or directly by server-side app code on the compose network.
-  fuseki: # dummy, in-memory; QLever joins later, side by side (decision #7)
+  fuseki: # dummy, in-memory; QLever runs side by side (decision #7)
     profiles: [full]
     image: stain/jena-fuseki:latest
     command: ["/jena-fuseki/fuseki-server", "--mem", "/betamasaheft"]
@@ -32,6 +32,10 @@ services:
   collatex:
     profiles: [full]
     image: ghcr.io/betamasaheft/collatex-service:main
+
+  qlever: # real SPARQL backend, side by side with dummy fuseki (decision #7)
+    profiles: [full]
+    image: ghcr.io/betamasaheft/sparql-service:main
 
 volumes:
   counter-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,5 +37,9 @@ services:
     profiles: [full]
     image: ghcr.io/betamasaheft/sparql-service:main
 
+  iipsrv: # fixture pyramidal TIFFs baked in, not real scans (#122)
+    profiles: [full]
+    image: ghcr.io/betamasaheft/iipsrv-fixtures:main
+
 volumes:
   counter-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,26 @@
 services:
+  # No host port: nginx is the sole public entry point, matching prod.
   betmas:
     build:
       context: .
       dockerfile: docker/app.Dockerfile
     image: ghcr.io/betamasaheft/betamasaheft:release-expanded
-    ports:
-      - 8083:8080
     environment:
-      APP_URL: http://localhost:8083/exist/apps/BetMasWeb
+      APP_URL: http://localhost:8080/exist/apps/BetMasWeb
   counter-app:
     build: ./counter-app
     image: ghcr.io/drrataplan/betamasaheft-counter-app:latest
     volumes:
       - counter-data:/exist/data
+
+  nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "8080:80"
+    volumes:
+      - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - betmas
 
 volumes:
   counter-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,16 @@ services:
     depends_on:
       - betmas
 
+  # `docker compose --profile full up`. No host ports - reached via
+  # nginx or directly by server-side app code on the compose network.
+  fuseki: # dummy, in-memory; QLever joins later, side by side (decision #7)
+    profiles: [full]
+    image: stain/jena-fuseki:latest
+    command: ["/jena-fuseki/fuseki-server", "--mem", "/betamasaheft"]
+
+  collatex:
+    profiles: [full]
+    image: ghcr.io/betamasaheft/collatex-service:main
+
 volumes:
   counter-data:

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -6,7 +6,7 @@
 # this image never re-runs the data step — produces the release-expanded tag.
 #
 # BetMasService/parser still come from db/apps/ (no standalone repo yet).
-# BetMasApi/BetMasWeb are fetched from their own repos instead.
+# BetMasApi/BetMasWeb/Dillmann are fetched from their own repos instead.
 #
 # Local build (base from ghcr, or --build-arg BETMAS_DATA_IMAGE=betmas-data:local):
 #   docker build -f docker/app.Dockerfile -t betamasaheft:local .
@@ -18,11 +18,13 @@ ARG BUILDER_IMAGE=ghcr.io/eeditiones/builder:latest
 # like a data.Dockerfile data package, not COPY'd from here.
 ARG BETMASAPI_REF=main
 ARG BETMASWEB_REF=main
+ARG DILLMANN_REF=master
 
 FROM ${BUILDER_IMAGE} AS build
 
 ARG BETMASAPI_REF
 ARG BETMASWEB_REF
+ARG DILLMANN_REF
 
 COPY db/apps/BetMasService /tmp/BetMasService
 COPY db/apps/parser /tmp/parser
@@ -51,6 +53,16 @@ RUN jar cfM0 /tmp/apps/13-parser.xar .
 WORKDIR /tmp/BetMas
 RUN jar cfM0 /tmp/apps/14-BetMas.xar .
 
+# Dillmann shares this instance rather than its own container (#556) -
+# matches prod. Unlike collatex-service/sparql-service/iipsrv-fixtures
+# (separate containers, own published images), this couples Dillmann's
+# release cadence to this image's rebuild. Decoupling it the same way
+# would be a real win - means accepting a prod-topology diff first.
+ADD https://github.com/BetaMasaheft/DillmannData/releases/latest/download/dill-data.xar /tmp/apps/15-DillmannData.xar
+ADD https://github.com/BetaMasaheft/Dillmann.git#${DILLMANN_REF} /tmp/Dillmann
+WORKDIR /tmp/Dillmann
+RUN ant && mv build/*.xar /tmp/apps/16-Dillmann.xar
+
 WORKDIR /tmp/BetMasInitInstance
 RUN jar cfM0 /tmp/stage-2/BetMasInitInstance.xar .
 
@@ -59,12 +71,14 @@ FROM ${BETMAS_DATA_IMAGE}
 
 ARG BETMASAPI_REF
 ARG BETMASWEB_REF
+ARG DILLMANN_REF
 ARG APP_COMMIT=unpinned
 LABEL org.opencontainers.image.source="https://github.com/BetaMasaheft/BetMas" \
-      org.opencontainers.image.description="BetaMasaheft app image: BetMasWeb + BetMasService + BetMasApi + parser on the betmas-data base" \
+      org.opencontainers.image.description="BetaMasaheft app image: BetMasWeb + BetMasService + BetMasApi + parser + Dillmann on the betmas-data base" \
       eu.betamasaheft.ref.betmas=${APP_COMMIT} \
       eu.betamasaheft.ref.betmasapi=${BETMASAPI_REF} \
-      eu.betamasaheft.ref.betmasweb=${BETMASWEB_REF}
+      eu.betamasaheft.ref.betmasweb=${BETMASWEB_REF} \
+      eu.betamasaheft.ref.dillmann=${DILLMANN_REF}
 
 COPY --from=build /tmp/apps/*.xar /exist/autodeploy/
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,6 +1,6 @@
 # Sole public entry point, matching prod. Ported from docs/nginx-config,
 # minus SSL/certs and bot-blocking (references map{} bodies not
-# captured here). iiif/Dillmann land once those services exist (#122).
+# captured here). iiif lands once that service exists (#122).
 
 server {
 	listen 80;
@@ -8,6 +8,12 @@ server {
 
 	location / {
 		proxy_pass http://betmas:8080/exist/apps/BetMasWeb/;
+	}
+
+	# Same instance as the main app, not a separate profile-gated
+	# container, so no resolver/rewrite trick needed here.
+	location /Dillmann/ {
+		proxy_pass http://betmas:8080/exist/apps/gez-en/;
 	}
 
 	# $variable in proxy_pass skips nginx's prefix-stripping - rewrite first.

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,11 +1,25 @@
 # Sole public entry point, matching prod. Ported from docs/nginx-config,
 # minus SSL/certs and bot-blocking (references map{} bodies not
-# captured here). fuseki/collatex/iiif/Dillmann land later (#122).
+# captured here). iiif/Dillmann land once those services exist (#122).
 
 server {
 	listen 80;
+	resolver 127.0.0.11 valid=10s; # for the full-profile upstreams below
 
 	location / {
 		proxy_pass http://betmas:8080/exist/apps/BetMasWeb/;
+	}
+
+	# $variable in proxy_pass skips nginx's prefix-stripping - rewrite first.
+	location /fuseki/ {
+		set $fuseki_upstream fuseki:3030;
+		rewrite ^/fuseki/(.*)$ /$1 break;
+		proxy_pass http://$fuseki_upstream;
+	}
+
+	location /collatex/ {
+		set $collatex_upstream collatex:17105;
+		rewrite ^/collatex/(.*)$ /$1 break;
+		proxy_pass http://$collatex_upstream;
 	}
 }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,10 +1,15 @@
 # Sole public entry point, matching prod. Ported from docs/nginx-config,
 # minus SSL/certs and bot-blocking (references map{} bodies not
-# captured here). iiif lands once that service exists (#122).
+# captured here).
 
 server {
 	listen 80;
 	resolver 127.0.0.11 valid=10s; # for the full-profile upstreams below
+
+	# Real prod points this at real TIFFs; here it points at iipsrv-fixtures'
+	# baked-in synthetic pages, using the same directory/facs-id shape a
+	# real Ethio-SPaRe manuscript uses.
+	rewrite ^/iiif/(.*) /iipsrv/iipsrv.fcgi?IIIF=/$1 last;
 
 	location / {
 		proxy_pass http://betmas:8080/exist/apps/BetMasWeb/;
@@ -35,5 +40,18 @@ server {
 		set $qlever_upstream qlever:7000;
 		rewrite ^/qlever/(.*)$ /$1 break;
 		proxy_pass http://$qlever_upstream;
+	}
+
+	location /iipsrv/iipsrv.fcgi {
+		set $iipsrv_upstream iipsrv:9000;
+		fastcgi_pass $iipsrv_upstream;
+		fastcgi_param PATH_INFO $fastcgi_script_name;
+		fastcgi_param REQUEST_METHOD $request_method;
+		fastcgi_param QUERY_STRING $query_string;
+		fastcgi_param CONTENT_TYPE $content_type;
+		fastcgi_param CONTENT_LENGTH $content_length;
+		fastcgi_param SERVER_PROTOCOL $server_protocol;
+		fastcgi_param REQUEST_URI $request_uri;
+		add_header Access-Control-Allow-Origin *;
 	}
 }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,11 @@
+# Sole public entry point, matching prod. Ported from docs/nginx-config,
+# minus SSL/certs and bot-blocking (references map{} bodies not
+# captured here). fuseki/collatex/iiif/Dillmann land later (#122).
+
+server {
+	listen 80;
+
+	location / {
+		proxy_pass http://betmas:8080/exist/apps/BetMasWeb/;
+	}
+}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -22,4 +22,12 @@ server {
 		rewrite ^/collatex/(.*)$ /$1 break;
 		proxy_pass http://$collatex_upstream;
 	}
+
+	# No prod precedent (prod's /fuseki/ still serves the old Fuseki);
+	# exposed for consistency with the other full-profile services above.
+	location /qlever/ {
+		set $qlever_upstream qlever:7000;
+		rewrite ^/qlever/(.*)$ /$1 break;
+		proxy_pass http://$qlever_upstream;
+	}
 }


### PR DESCRIPTION
## Summary

nginx fronts the app as the compose stack's sole public entry point, matching prod (#122). `betmas` has no host port - a second directly-exposed entry point means `APP_URL` can only be correct for one of them, and an earlier pass with dual access proved that immediately: links served through nginx kept pointing at the direct port instead.

Also adds the `full` profile: dummy in-memory Fuseki + QLever side by side (decision #7), `collatex-service`, and `iipsrv-fixtures` (synthetic pyramidal TIFFs, real scans land once that's wired up). All resolved at request time (embedded Docker resolver + `$variable`), not config-load time, so nginx still starts fine without `--profile full`.

Dillmann now shares the app's eXist instance rather than its own container, matching prod's topology (Dillmann#556). Inline comments in `app.Dockerfile` flag this as a coupling worth decoupling later, once a prod-topology diff is acceptable.

`docker/nginx.conf` ports the app/fuseki/collatex/qlever/iiif/Dillmann locations from `docs/nginx-config`, minus SSL/certs and bot-blocking (references `map{}` bodies not captured here).

## Real bugs found and fixed during verification

- **APP_URL/link drift**: dual access meant nginx-served pages emitted links to the direct port. Fixed by dropping the direct port entirely.
- **nginx prefix-stripping**: a variable in `proxy_pass` skips nginx's usual strip-the-location-prefix behaviour, so Fuseki was getting the unstripped path and silently serving its UI shell instead of the real query result - looked like it worked until compared against direct access. Fixed with `rewrite ... break`.

## Verified

- `betmas` has zero host ports, nginx-served pages emit correct links
- `/fuseki/`, `/collatex/`, `/qlever/` all byte-identical to bypassing nginx entirely
- `/Dillmann/` serves real content from the shared instance
- `/iiif/...` serves a real fixture JPEG end-to-end through nginx -> fastcgi -> iipsrv
- Default profile (no `full`): nginx still starts, gated routes 502 instead of crashing
- One route 504'd once - confirmed that's the pre-existing `digi.vatlib.it` retry storm (BetaMasaheft/BetMasWeb#19), not nginx

## Test plan

- [x] `docker compose up --build betmas nginx`: clean start, zero host ports on `betmas`
- [x] `docker compose --profile full up`: all containers start clean
- [x] `curl localhost:8083`: connection refused
- [x] `/fuseki/`, `/collatex/`, `/qlever/` via nginx match direct access
- [x] `/Dillmann/...` and `/iiif/.../full/full/0/default.jpg` via nginx return real content
