### PR TITLE
build(compose): add fuseki + collatex-service to the full profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,16 @@ services:
     depends_on:
       - betmas
 
+  # `docker compose --profile full up`. No host ports - reached via
+  # nginx or directly by server-side app code on the compose network.
+  fuseki: # dummy, in-memory; QLever joins later, side by side (decision #7)
+    profiles: [full]
+    image: stain/jena-fuseki:latest
+    command: ["/jena-fuseki/fuseki-server", "--mem", "/betamasaheft"]
+
+  collatex:
+    profiles: [full]
+    image: ghcr.io/betamasaheft/collatex-service:main
+
 volumes:
   counter-data:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,11 +1,25 @@
 # Sole public entry point, matching prod. Ported from docs/nginx-config,
 # minus SSL/certs and bot-blocking (references map{} bodies not
-# captured here). fuseki/collatex/iiif/Dillmann land later (#122).
+# captured here). iiif/Dillmann land once those services exist (#122).
 
 server {
 	listen 80;
+	resolver 127.0.0.11 valid=10s; # for the full-profile upstreams below
 
 	location / {
 		proxy_pass http://betmas:8080/exist/apps/BetMasWeb/;
+	}
+
+	# $variable in proxy_pass skips nginx's prefix-stripping - rewrite first.
+	location /fuseki/ {
+		set $fuseki_upstream fuseki:3030;
+		rewrite ^/fuseki/(.*)$ /$1 break;
+		proxy_pass http://$fuseki_upstream;
+	}
+
+	location /collatex/ {
+		set $collatex_upstream collatex:17105;
+		rewrite ^/collatex/(.*)$ /$1 break;
+		proxy_pass http://$collatex_upstream;
 	}
 }


### PR DESCRIPTION
## Summary

First two "full" profile services (#122): dummy in-memory Fuseki (decision #7 - QLever joins later, side by side) and `ghcr.io/betamasaheft/collatex-service:main`. No host ports - reached via nginx or directly by app code.

nginx resolves both at request time (embedded Docker resolver + `$variable`), not config-load time, so it still starts fine without `--profile full`.

## Bug found and fixed during verification

A variable in `proxy_pass` skips nginx's usual prefix-stripping, so Fuseki was getting the unstripped path and silently serving its UI shell instead of the real query result - looked like it "worked" until compared against direct access. Fixed with `rewrite ... break`; both locations now verified byte-identical to bypassing nginx entirely.

## Test plan

- [x] `docker compose --profile full up`: all four containers start clean
- [x] `/fuseki/betamasaheft/query?query=ASK {}` via nginx matches direct access exactly
- [x] `/collatex/collate` via nginx matches direct access exactly
- [x] Default profile (no fuseki/collatex): nginx still starts, `/fuseki/` 502s instead of crashing
