### PR TITLE
build(compose): add QLever to the full profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
   # `docker compose --profile full up`. No host ports - reached via
   # nginx or directly by server-side app code on the compose network.
-  fuseki: # dummy, in-memory; QLever joins later, side by side (decision #7)
+  fuseki: # dummy, in-memory; QLever runs side by side (decision #7)
     profiles: [full]
     image: stain/jena-fuseki:latest
     command: ["/jena-fuseki/fuseki-server", "--mem", "/betamasaheft"]
@@ -32,6 +32,10 @@ services:
   collatex:
     profiles: [full]
     image: ghcr.io/betamasaheft/collatex-service:main
+
+  qlever: # real SPARQL backend, side by side with dummy fuseki (decision #7)
+    profiles: [full]
+    image: ghcr.io/betamasaheft/sparql-service:main
 
 volumes:
   counter-data:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -22,4 +22,12 @@ server {
 		rewrite ^/collatex/(.*)$ /$1 break;
 		proxy_pass http://$collatex_upstream;
 	}
+
+	# No prod precedent (prod's /fuseki/ still serves the old Fuseki);
+	# exposed for consistency with the other full-profile services above.
+	location /qlever/ {
+		set $qlever_upstream qlever:7000;
+		rewrite ^/qlever/(.*)$ /$1 break;
+		proxy_pass http://$qlever_upstream;
+	}
 }


### PR DESCRIPTION
Real SPARQL backend (#122), side by side with dummy Fuseki (decision #7): `ghcr.io/betamasaheft/sparql-service:main`, no host port, same resolver+rewrite nginx pattern as `fuseki`/`collatex`.

**Judgment call**: added an nginx `/qlever/` location even though prod has no QLever path yet (its `/fuseki/` still serves the old Fuseki) - for consistency with the other full-profile services and easy debugging, at no cost since it's profile-gated behind `full`.

Verified locally:
- `qlever` starts clean under `--profile full`, indexes/serves real data (3.1M triples) on first query, no extra setup
- direct query (`docker compose exec qlever curl ...`) and via `/qlever/` return byte-identical results (modulo per-run `.meta` timing)
- default profile (no `full`) still starts clean, zero errors
- cleaned up all containers after verification