### PR TITLE
fix(compose): point APP_URL at nginx's root, not the eXist mount path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,10 @@ services:
       dockerfile: docker/app.Dockerfile
     image: ghcr.io/betamasaheft/betamasaheft:release-expanded
     environment:
-      APP_URL: http://localhost:8080/exist/apps/BetMasWeb
+      # nginx is the sole public entry point (proxies "/" to this app), so
+      # the app's externally-visible base is root now, not its own eXist
+      # mount path.
+      APP_URL: http://localhost:8080
   counter-app:
     build: ./counter-app
     image: ghcr.io/drrataplan/betamasaheft-counter-app:latest


### PR DESCRIPTION
## Summary
nginx (#130) is the stack's sole public entry point and proxies "/" to the app's own eXist mount, but `APP_URL` was never updated for that shift - the app kept rendering absolute links against its old, now-internal-only base path (`http://localhost:8080/exist/apps/BetMasWeb`). Those links resolve outside nginx's routing entirely (doubled path -> 404 on nearly every internal link: search, manuscript views, id lookups, etc). Same bug class as BP-008, reintroduced by #130.

## Verification
- Rebuilt the container with `APP_URL: http://localhost:8080` and confirmed rendered links are now root-relative (`href="http://localhost:8080/newSearch.html"` instead of the doubled-path form).
- Ran betmas-e2e's full container Cypress suite against the fixed stack: failures caused by this bug (manuscripts-browse, works, simpleSearch, id, and others - 16 specs) all resolved. See BetaMasaheft/betmas-e2e#76, which depends on this fix landing before it can go green in real CI.

Refs #122