### PR TITLE
fix(nginx): rewrite the session cookie's Path so it survives navigation

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -11,14 +11,21 @@ server {
 	# real Ethio-SPaRe manuscript uses.
 	rewrite ^/iiif/(.*) /iipsrv/iipsrv.fcgi?IIIF=/$1 last;
 
+	# eXist sets its session cookie's Path to its own servlet context
+	# (/exist), which the browser never sees behind this proxy - without
+	# rewriting it here, the cookie is silently dropped on the very next
+	# navigation (RFC 6265 path scoping), breaking any login that survives
+	# past the response that set it.
 	location / {
 		proxy_pass http://betmas:8080/exist/apps/BetMasWeb/;
+		proxy_cookie_path /exist /;
 	}
 
 	# Same instance as the main app, not a separate profile-gated
 	# container, so no resolver/rewrite trick needed here.
 	location /Dillmann/ {
 		proxy_pass http://betmas:8080/exist/apps/gez-en/;
+		proxy_cookie_path /exist /;
 	}
 
 	# $variable in proxy_pass skips nginx's prefix-stripping - rewrite first.


### PR DESCRIPTION
## Summary
eXist sets its session cookie's `Path` to its own servlet context (`/exist`), which the browser never sees behind this proxy. Per RFC 6265 a cookie scoped to `Path=/exist` is never re-sent for requests to `/` - so a login was established correctly (the response that set the cookie renders logged-in), then silently dropped on the very next navigation.

This was invisible to most specs, which only ever inspect the DOM from the login response itself. betmas-e2e#77 ("Logging in from subpages") does an extra navigate-away-and-back cycle and consistently caught it - initially suspected to be a Cypress-only quirk since raw `curl` login appeared to "work" (it does render logged-in in that one response; the bug only shows up one request later).

## Fix
`proxy_cookie_path /exist /;` on the two locations that proxy into the eXist app (`/` and `/Dillmann/`), rewriting the cookie's `Path` to match the public URL space nginx actually serves.

## Verification
- `curl`: cookie now comes back `Path=/`, and a session survives a follow-up `GET /` (previously reverted to guest).
- betmas-e2e's full container Cypress suite: **62/62 specs green**, up from 61/62 - every other spec was silently exercising this same broken session machinery on a much shorter fuse (single-response checks only), this is the first fully clean run of the composed-stack suite.

Refs betmas-e2e#77, #122