### PR TITLE
fix(nginx): route /api/ to BetMasApi + set the missing FUSEKI_URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,10 @@ services:
       # the app's externally-visible base is root now, not its own eXist
       # mount path.
       APP_URL: http://localhost:8080
+      # Only reachable with the full profile (fuseki isn't in core), but
+      # harmless to set unconditionally - config:service-url() only
+      # resolves this when something actually calls out to Fuseki.
+      FUSEKI_URL: http://fuseki:3030/
   counter-app:
     build: ./counter-app
     image: ghcr.io/drrataplan/betamasaheft-counter-app:latest

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -21,6 +21,25 @@ server {
 		proxy_cookie_path /exist /;
 	}
 
+	# BetMasWeb owns exactly these two /api/ routes itself (confirmed
+	# against both apps' route tables - zero overlap with BetMasApi).
+	# Everything else under /api/ (below) goes to BetMasApi, matching
+	# prod's real topology.
+	location = /api/collatex {
+		proxy_pass http://betmas:8080/exist/apps/BetMasWeb/api/collatex;
+		proxy_cookie_path /exist /;
+	}
+
+	location = /api/idlookup {
+		proxy_pass http://betmas:8080/exist/apps/BetMasWeb/api/idlookup;
+		proxy_cookie_path /exist /;
+	}
+
+	location /api/ {
+		proxy_pass http://betmas:8080/exist/apps/BetMasApi/api/;
+		proxy_cookie_path /exist /;
+	}
+
 	# Same instance as the main app, not a separate profile-gated
 	# container, so no resolver/rewrite trick needed here.
 	location /Dillmann/ {


### PR DESCRIPTION
## Summary
BetMasWeb's `controller.xql` absorbs all `/api/` traffic into its own partial Roaster router instead of reaching BetMasApi at all - most of BetMasApi's ~100 declared routes (`dts/collections`, SPARQL, gazetteer, clavis, etc.) 404 in the composed stack today. Long diagnosed, never fixed - see #134.

## Fix
Confirmed the actual ownership split before routing anything, rather than assume: grepped both apps' route tables. BetMasWeb genuinely owns exactly two `/api/` routes (`collatex`, `idlookup`) - its other `/api/dts/*` entries are prefixed `/BetMas/api/dts/...` (a base-path bug) and never match a real request anyway. Zero overlap with BetMasApi's ~100 paths.

Two exact-match nginx exceptions keep BetMasWeb's real routes working, a catch-all sends everything else to BetMasApi's own mount - same `proxy_cookie_path` fix as #136 (both apps share the same eXist instance's cookie).

**Bundled in (#138):** this same fix exposed that `FUSEKI_URL` was never actually set in `docker-compose.yml` - `/api/SPARQL/json` now reaches real code but was 500ing on a connection-refused, since `fuseki.xqm`'s default (`localhost:3030`) doesn't resolve inside the container network. Now set to the compose service name.

## Verification
- `/api/dts/collections` now returns BetMasApi's real `302` redirect (previously `404`).
- `/api/collatex` and `/api/idlookup` unaffected - still `200` via BetMasWeb.
- `/api/SPARQL/json` returns a real query result instead of a connection-refused `500`.
- Full betmas-e2e container suite: **62/62**, no regressions.

Refs #134, #138