### PR TITLE
fix(collatex): set the missing COLLATEX_URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ services:
       # harmless to set unconditionally - config:service-url() only
       # resolves this when something actually calls out to Fuseki.
       FUSEKI_URL: http://fuseki:3030/
+      # Same story as FUSEKI_URL above - only live under the full profile,
+      # harmless otherwise. Matches collatex-service's own EXPOSE 17105 and
+      # /collate endpoint.
+      COLLATEX_URL: http://collatex:17105/collate
   counter-app:
     build: ./counter-app
     image: ghcr.io/drrataplan/betamasaheft-counter-app:latest


### PR DESCRIPTION
## Summary
Same gap as `FUSEKI_URL` (#137/#138): `BetMasWeb`'s `config:collatexUrl` reads this env var via `config:service-url()`, but nothing in `docker-compose.yml` ever set it - so it silently fell back to its `localhost:8081` default, which doesn't exist in the composed stack. Points it at the real `collatex` service address (`EXPOSE 17105`, `/collate` endpoint, confirmed against `collatex-service`'s own Dockerfile).

## Verification
Booted the `full` profile locally with this change and hit `/api/collatex` through nginx directly - the request now reaches `collatex.xqm`'s DTS-URN validation logic (`please provide at least 2 dts URIs...`) instead of failing to connect, confirming the URL/port fix itself is correct.

Found a second, separate bug while testing with real DTS URNs: `BetMasWeb/modules/dtslib.xqm:71`'s `$dtslib:regexID` has every capture group wrapped optional, so the whole pattern can match a zero-length string - `analyze-string()` forbids that outright (`err:FORX0003`), independent of data freshness (reproduced against the just-rebuilt image with real `expanded` data). That's a `BetMasWeb` code bug, out of scope here - will file separately.

Draft per "wait for fresh containers" - fresh image confirmed pulled and used for the verification above.