### PR TITLE
feat(container): wire Guidelines into the app image + nginx

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -6,7 +6,7 @@
 # this image never re-runs the data step — produces the release-expanded tag.
 #
 # BetMasService/parser still come from db/apps/ (no standalone repo yet).
-# BetMasApi/BetMasWeb/Dillmann are fetched from their own repos instead.
+# BetMasApi/BetMasWeb/Dillmann/guidelinesApp are fetched from their own repos instead.
 #
 # Local build (base from ghcr, or --build-arg BETMAS_DATA_IMAGE=betmas-data:local):
 #   docker build -f docker/app.Dockerfile -t betamasaheft:local .
@@ -19,12 +19,14 @@ ARG BUILDER_IMAGE=ghcr.io/eeditiones/builder:latest
 ARG BETMASAPI_REF=main
 ARG BETMASWEB_REF=main
 ARG DILLMANN_REF=master
+ARG GUIDELINESAPP_REF=master
 
 FROM ${BUILDER_IMAGE} AS build
 
 ARG BETMASAPI_REF
 ARG BETMASWEB_REF
 ARG DILLMANN_REF
+ARG GUIDELINESAPP_REF
 
 COPY db/apps/BetMasService /tmp/BetMasService
 COPY db/apps/parser /tmp/parser
@@ -63,6 +65,18 @@ ADD https://github.com/BetaMasaheft/Dillmann.git#${DILLMANN_REF} /tmp/Dillmann
 WORKDIR /tmp/Dillmann
 RUN ant && mv build/*.xar /tmp/apps/16-Dillmann.xar
 
+# Guidelines shares this instance too (betmas-e2e#67 - never wired into any
+# container before this). Same shape as Dillmann: release-asset data +
+# schema deps, then the app built from source. html-templating (its other
+# declared dependency) needs no separate install - it's an eXist core
+# module, already proven working in this image via BetMasWeb's own
+# %templates:wrap usage.
+ADD https://github.com/BetaMasaheft/Schema/releases/latest/download/betamas-schemas.xar /tmp/apps/17-Schema.xar
+ADD https://github.com/BetaMasaheft/guidelines/releases/latest/download/guidelines-data.xar /tmp/apps/18-GuidelinesData.xar
+ADD https://github.com/BetaMasaheft/guidelinesApp.git#${GUIDELINESAPP_REF} /tmp/guidelinesApp
+WORKDIR /tmp/guidelinesApp
+RUN ant && mv build/*.xar /tmp/apps/19-guidelinesApp.xar
+
 WORKDIR /tmp/BetMasInitInstance
 RUN jar cfM0 /tmp/stage-2/BetMasInitInstance.xar .
 
@@ -72,13 +86,15 @@ FROM ${BETMAS_DATA_IMAGE}
 ARG BETMASAPI_REF
 ARG BETMASWEB_REF
 ARG DILLMANN_REF
+ARG GUIDELINESAPP_REF
 ARG APP_COMMIT=unpinned
 LABEL org.opencontainers.image.source="https://github.com/BetaMasaheft/BetMas" \
-      org.opencontainers.image.description="BetaMasaheft app image: BetMasWeb + BetMasService + BetMasApi + parser + Dillmann on the betmas-data base" \
+      org.opencontainers.image.description="BetaMasaheft app image: BetMasWeb + BetMasService + BetMasApi + parser + Dillmann + Guidelines on the betmas-data base" \
       eu.betamasaheft.ref.betmas=${APP_COMMIT} \
       eu.betamasaheft.ref.betmasapi=${BETMASAPI_REF} \
       eu.betamasaheft.ref.betmasweb=${BETMASWEB_REF} \
-      eu.betamasaheft.ref.dillmann=${DILLMANN_REF}
+      eu.betamasaheft.ref.dillmann=${DILLMANN_REF} \
+      eu.betamasaheft.ref.guidelinesapp=${GUIDELINESAPP_REF}
 
 COPY --from=build /tmp/apps/*.xar /exist/autodeploy/
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -47,6 +47,14 @@ server {
 		proxy_cookie_path /exist /;
 	}
 
+	# betmas-e2e#67: never routed anywhere before this - guidelinesApp's
+	# repo.xml target is "guidelines" (lowercase), matching prod's own
+	# https://betamasaheft.eu/Guidelines URL despite the case difference.
+	location /Guidelines/ {
+		proxy_pass http://betmas:8080/exist/apps/guidelines/;
+		proxy_cookie_path /exist /;
+	}
+
 	# $variable in proxy_pass skips nginx's prefix-stripping - rewrite first.
 	location /fuseki/ {
 		set $fuseki_upstream fuseki:3030;


### PR DESCRIPTION
## Summary
Guidelines (a separate standalone app, same shape as Dillmann) was never wired into any container - not in `app.Dockerfile`, not routed by nginx. Fixed, mirroring the Dillmann inclusion pattern exactly.

- Release-asset deps confirmed real and downloadable: `guidelines-data.xar` (`guidelines` repo), `betamas-schemas.xar` (`Schema` repo).
- `guidelinesApp` built from source (its own `ant` build, confirmed working).
- `html-templating` (its other declared expath dependency) needs no separate install - it's an eXist core module, already proven present in this image via `BetMasWeb`'s own `%templates:wrap` usage.
- nginx: `location /Guidelines/` added, same shape as the existing `/Dillmann/` route.

Refs betmas-e2e#67.

## Test plan
- [x] Verified end to end against a local container (hot-patched all 3 packages + reloaded nginx): search, pagination, and quick-links all render real content through `/Guidelines/`.
- [ ] Full `docker build -f docker/app.Dockerfile` not run locally (would rebuild BetMasWeb/BetMasApi/Dillmann/Guidelines from source, several minutes) - relying on CI + the identical, already-proven Dillmann pattern this copies exactly.