### PR TITLE
fix(container): build guidelinesApp from its nested guidelines/ dir

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -74,7 +74,9 @@ RUN ant && mv build/*.xar /tmp/apps/16-Dillmann.xar
 ADD https://github.com/BetaMasaheft/Schema/releases/latest/download/betamas-schemas.xar /tmp/apps/17-Schema.xar
 ADD https://github.com/BetaMasaheft/guidelines/releases/latest/download/guidelines-data.xar /tmp/apps/18-GuidelinesData.xar
 ADD https://github.com/BetaMasaheft/guidelinesApp.git#${GUIDELINESAPP_REF} /tmp/guidelinesApp
-WORKDIR /tmp/guidelinesApp
+# unlike BetMasWeb/BetMasApi/Dillmann, this repo's build.xml lives in a
+# nested guidelines/ subdirectory, not the repo root
+WORKDIR /tmp/guidelinesApp/guidelines
 RUN ant && mv build/*.xar /tmp/apps/19-guidelinesApp.xar
 
 WORKDIR /tmp/BetMasInitInstance


### PR DESCRIPTION
## Summary
The master-triggered image build (`Build and Push App Image`) failed after #140 merged, with `Buildfile: build.xml does not exist!`. Unlike BetMasWeb/BetMasApi/Dillmann, `guidelinesApp`'s repo root isn't the eXist app itself - the actual app (with `build.xml`) lives in a nested `guidelines/` subdirectory. This never surfaced in #140's PR-time CI since the docker build only runs on master push.

## Fix
`WORKDIR /tmp/guidelinesApp` -> `WORKDIR /tmp/guidelinesApp/guidelines` before the `ant` build step.

## Test plan
- [x] Verified locally: cloned `guidelinesApp`, ran `ant` from the `guidelines/` subdirectory - `BUILD SUCCESSFUL`, produces `guidelines-0.1.xar`.
- [ ] Master image build succeeds after merge.

Refs BetaMasaheft/betmas-e2e#67